### PR TITLE
SF-3026 Force consistent date format for Nepali across platforms

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -119,6 +119,9 @@ describe('I18nService', () => {
 
     service.setLocale('az');
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
+
+    service.setLocale('npi');
+    expect(service.formatDate(date)).toEqual('१९९१-११-२५, १७:२८');
   });
 
   it('should support including the timezone in the date', () => {


### PR DESCRIPTION
By default, Chrome on Windows defaults to standard English formatting for Nepali dates, whereas Chrome on Android uses Nepali script and formatting (to an extent). This change supplies a custom date format that all platforms will use. It gets as close to the appropriate date/time format as possible with what's built into the standard API.

The one difference/shortcoming of which I'm aware is that Nepal uses the Vikram Samvat calendar, which is not supported with the 'calendar' option. We could use the 'indian' calendar, but given that Android defaults to Nepali script and Gregorian calendar, it should be acceptable to do so here, as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for date localization in the 'npi' locale, enhancing the date formatting capabilities.
- **Bug Fixes**
	- Ensured existing date formats continue to function correctly alongside the new locale support.
- **Tests**
	- Introduced a new test case for validating date formatting in the 'npi' locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->