### PR TITLE
CacheService disposes of older subscriptions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -39,6 +39,7 @@ import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
 import { roleCanAccessTranslate } from './core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from './core/models/sf-project-user-config-doc';
 import { SFProjectService } from './core/sf-project.service';
+import { CacheService } from './shared/cache-service/cache.service';
 import { checkAppAccess } from './shared/utils';
 
 declare function gtag(...args: any): void;
@@ -77,6 +78,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly fileService: FileService,
     private readonly reportingService: ErrorReportingService,
     private readonly activatedProjectService: ActivatedProjectService,
+    private readonly cacheService: CacheService,
     private readonly locationService: LocationService,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly breakpointService: MediaBreakpointService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
@@ -3,22 +3,27 @@ import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
+import { BehaviorSubject } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
+import { MemoryRealtimeDocAdapter } from '../../../xforge-common/memory-realtime-remote-store';
+import { RealtimeDocAdapter } from '../../../xforge-common/realtime-remote-store';
 import { AppComponent } from '../../app.component';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
-import { TextDocId } from '../../core/models/text-doc';
+import { TextDoc, TextDocId } from '../../core/models/text-doc';
 import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { CacheService } from './cache.service';
 
 const mockedProjectService = mock(SFProjectService);
-const mockedProjectDoc = mock(SFProjectProfileDoc);
 const mockedPermissionService = mock(PermissionsService);
+const mockedActivatedProject = mock(ActivatedProjectService);
+const projectId$ = new BehaviorSubject<string>('');
 
 describe('cache service', () => {
   configureTestingModule(() => ({
@@ -32,14 +37,21 @@ describe('cache service', () => {
     ],
     providers: [
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: PermissionsService, useMock: mockedPermissionService }
+      { provide: PermissionsService, useMock: mockedPermissionService },
+      { provide: ActivatedProjectService, useMock: mockedActivatedProject }
     ]
   }));
+
   describe('load all texts', () => {
+    beforeEach(() => {
+      const text = { adapter: instance(mock<RealtimeDocAdapter>()) } as TextDoc;
+      when(mockedProjectService.getText(anything())).thenResolve(text);
+      when(mockedActivatedProject.projectId$).thenReturn(projectId$);
+    });
+
     it('does not get texts from project service if no permission', fakeAsync(async () => {
-      const env = new TestEnvironment();
       when(mockedPermissionService.canAccessText(anything())).thenResolve(false);
-      await env.service.cache(env.projectDoc);
+      const env = new TestEnvironment();
       env.wait();
 
       verify(mockedProjectService.getText(anything())).times(0);
@@ -50,38 +62,62 @@ describe('cache service', () => {
 
     it('gets all texts from project service', fakeAsync(async () => {
       const env = new TestEnvironment();
-      await env.service.cache(env.projectDoc);
       env.wait();
+      flush();
 
-      verify(mockedProjectService.getText(anything())).times(200 * 100 * 2);
+      verify(mockedProjectService.getText(anything())).times(20 * 10 * 2);
 
       flush();
       expect(true).toBeTruthy();
     }));
 
     it('stops the current operation if cache is called again', fakeAsync(async () => {
-      const env = new TestEnvironment();
+      // configure the first project to interrupt itself
+      let timesCalled = 0;
+      const text = { adapter: instance(mock(MemoryRealtimeDocAdapter)) as RealtimeDocAdapter } as TextDoc;
+      when(mockedProjectService.getText(anything())).thenCall(async () => {
+        ++timesCalled;
+        if (timesCalled > 1) {
+          await cacheNewProject();
+        }
 
-      const mockProject = mock(SFProjectProfileDoc);
-      when(mockProject.id).thenReturn('new project');
-      const data = createTestProjectProfile({
-        texts: env.createTexts()
+        return text;
       });
-      when(mockProject.data).thenReturn(data);
 
-      env.service.cache(env.projectDoc);
-      await env.service.cache(instance(mockProject));
+      // configure the new project
+      when(
+        mockedProjectService.getText(deepEqual(new TextDocId('new project', anything(), anything(), 'target')))
+      ).thenResolve(text);
+
+      const env = new TestEnvironment();
+      when(
+        mockedPermissionService.canAccessText(deepEqual(new TextDocId('sourceId', anything(), anything(), 'target')))
+      ).thenResolve(false); // remove source permissions for simpler test calculations
+
       env.wait();
+      flush();
 
       verify(
         mockedProjectService.getText(deepEqual(new TextDocId('new project', anything(), anything(), 'target')))
-      ).times(200 * 100);
+      ).times(20 * 10);
 
       //verify at least some books were not gotten
-      verify(mockedProjectService.getText(anything())).atMost(200 * 100 * 2 - 1);
+      verify(mockedProjectService.getText(anything())).atMost(20 * 10 * 2 - 1);
 
       flush();
       expect(true).toBeTruthy();
+
+      async function cacheNewProject(): Promise<void> {
+        const mockProject = mock(SFProjectProfileDoc);
+        when(mockProject.id).thenReturn('new project');
+        const data = createTestProjectProfile({
+          texts: env.createTexts()
+        });
+        when(mockProject.data).thenReturn(data);
+
+        await env.service['cache'](instance(mockProject));
+        env.wait();
+      }
     }));
 
     it('gets the source texts if they are present and the user can access', fakeAsync(async () => {
@@ -90,14 +126,60 @@ describe('cache service', () => {
         false
       ); //remove access for one source doc
 
-      await env.service.cache(env.projectDoc);
       env.wait();
+      flush();
 
       //verify all sources and targets were gotten except the inaccessible one
-      verify(mockedProjectService.getText(anything())).times(200 * 100 * 2 - 1);
+      verify(mockedProjectService.getText(anything())).times(20 * 10 * 2 - 1);
 
       flush();
       expect(true).toBeTruthy();
+    }));
+
+    it('destroys the old text subscriptions when switching to a new project', fakeAsync(async () => {
+      //save all adapters for original project
+      const adapterMocks: RealtimeDocAdapter[] = [];
+      for (let book = 0; book < 20; book++) {
+        for (let chapter = 0; chapter < 10; chapter++) {
+          when(mockedProjectService.getText(deepEqual(new TextDocId(anything(), book, chapter, 'target')))).thenCall(
+            _ => {
+              const adapterMock = mock<RealtimeDocAdapter>();
+              adapterMocks.push(adapterMock);
+              return { adapter: instance(adapterMock) } as TextDoc;
+            }
+          );
+        }
+      }
+
+      //ensure new project doesn't add its adapters to the above list
+      when(
+        mockedProjectService.getText(deepEqual(new TextDocId('new project', anything(), anything(), 'target')))
+      ).thenResolve({ adapter: instance(mock(MemoryRealtimeDocAdapter)) as RealtimeDocAdapter } as TextDoc);
+
+      const env = new TestEnvironment();
+      env.wait();
+      flush();
+
+      //trigger a project change
+      when(mockedProjectService.getProfile('new project')).thenResolve({
+        id: 'new project',
+        data: createTestProjectProfile({ texts: env.createTexts() })
+      } as SFProjectProfileDoc);
+      projectId$.next('new project');
+      env.wait();
+      flush();
+
+      //verify all adapters are destroyed
+      for (const adapterMock of adapterMocks) {
+        verify(adapterMock.destroy()).once();
+      }
+
+      //verify no original adapter is present
+      for (const text of env.service['subscribedTexts']) {
+        for (const adapterMock of adapterMocks) {
+          expect(text.adapter).not.toBe(instance(adapterMock));
+        }
+      }
     }));
   });
 });
@@ -105,11 +187,8 @@ describe('cache service', () => {
 class TestEnvironment {
   readonly ngZone: NgZone = TestBed.inject(NgZone);
   readonly service: CacheService;
-  readonly projectDoc: SFProjectProfileDoc = instance(mockedProjectDoc);
 
   constructor() {
-    this.service = TestBed.inject(CacheService);
-
     const data = createTestProjectProfile({
       texts: this.createTexts(),
       translateConfig: {
@@ -119,15 +198,17 @@ class TestEnvironment {
       }
     });
 
-    when(mockedProjectDoc.data).thenReturn(data);
     when(mockedPermissionService.canAccessText(anything())).thenResolve(true);
+    when(mockedProjectService.getProfile(anything())).thenResolve({ data } as SFProjectProfileDoc);
+
+    this.service = TestBed.inject(CacheService);
   }
 
   createTexts(): TextInfo[] {
     const texts: TextInfo[] = [];
-    for (let book = 0; book < 200; book++) {
+    for (let book = 0; book < 20; book++) {
       const chapters: Chapter[] = [];
-      for (let chapter = 0; chapter < 100; chapter++) {
+      for (let chapter = 0; chapter < 10; chapter++) {
         chapters.push({ isValid: true, lastVerse: 1, number: chapter, permissions: {}, hasAudio: false });
       }
       texts.push({ bookNum: book, chapters: chapters, hasSource: true, permissions: {} });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -5,9 +5,7 @@ import ObjectID from 'bson-objectid';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, map, startWith, switchMap } from 'rxjs/operators';
 import { SFProjectProfileDoc } from '../app/core/models/sf-project-profile-doc';
-import { PermissionsService } from '../app/core/permissions.service';
 import { SFProjectService } from '../app/core/sf-project.service';
-import { CacheService } from '../app/shared/cache-service/cache.service';
 import { SubscriptionDisposable } from './subscription-disposable';
 
 interface IActiveProjectIdService {
@@ -55,7 +53,6 @@ export class ActivatedProjectService extends SubscriptionDisposable {
 
   constructor(
     private readonly projectService: SFProjectService,
-    private readonly cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
     super();
@@ -83,9 +80,6 @@ export class ActivatedProjectService extends SubscriptionDisposable {
   private set projectDoc(projectDoc: SFProjectProfileDoc | undefined) {
     if (this.projectDoc !== projectDoc) {
       this._projectDoc$.next(projectDoc);
-      if (this.projectDoc !== undefined) {
-        this.cacheService.cache(this.projectDoc);
-      }
     }
   }
 
@@ -125,19 +119,13 @@ export class TestActiveProjectIdService implements IActiveProjectIdService {
 export class TestActivatedProjectService extends ActivatedProjectService {
   constructor(
     projectService: SFProjectService,
-    cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
-    super(projectService, cacheService, activeProjectIdService);
+    super(projectService, activeProjectIdService);
   }
 
   static withProjectId(projectId: string): TestActivatedProjectService {
     const projectService = TestBed.inject(SFProjectService);
-    const permissionsService = TestBed.inject(PermissionsService);
-    return new TestActivatedProjectService(
-      projectService,
-      new CacheService(projectService, permissionsService),
-      new TestActiveProjectIdService(projectId)
-    );
+    return new TestActivatedProjectService(projectService, new TestActiveProjectIdService(projectId));
   }
 }


### PR DESCRIPTION
The CacheService was subscribing to all chapters for each project visited during the lifetime of the app. This was causing memory issues for the server, though this hasn't always been a problem. I'm not exactly sure what changed -- maybe the space for each chapter is growing, or we're getting more concurrent users. This changes the CacheService to uncache its subscriptions, when the project changes, before subscribing to the new chapters. I verified with the Node Dev Tools in Chrome that, while the number of ClientSessions still grows, the memory usage does not grow when switching projects.

I also took the opportunity to refactor away the service's dependence on some other class to tell it when to cache. It now listens to the activated project and cues its own operations. You simply need to reference it somewhere (currently in app.component).

I of course updated the tests and, as part of this, reduced the total number of chapters being used in the tests. I had to reduce this number, because the 20000 mock creations (or something) were crashing the test client. I'm sad to say it couldn't even handle 2000, but I believe the tests are just as effective at 200. I also reworked one of the more interesting tests to be more explicit/dependable.