### PR TITLE
SF-2829 Allow paratext roles that have changed to be updated

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
@@ -5,6 +5,8 @@ export interface ParatextProject {
   shortName: string;
   languageTag: string;
   projectId?: string;
+  projectUserRole: string;
   isConnectable: boolean;
   isConnected: boolean;
+  userRoleNeedsUpdated: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -12,21 +12,39 @@
       </h2>
     }
     @for (projectDoc of userConnectedProjects; track projectDoc) {
-      <mat-card
-        [class.active-project]="isLastSelectedProject(projectDoc)"
-        id="user-connected-project-card-{{ projectDoc.data?.paratextId }}"
-        [attr.data-pt-project-id]="projectDoc.data?.paratextId"
-        class="user-connected-project mat-elevation-z4"
-        appRouterLink="/projects/{{ projectDoc.id }}"
-        matRipple
-      >
-        <span class="project-name">
-          <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}
-        </span>
-        <span class="project-description">
-          {{ projectTypeDescription(projectDoc) }}
-        </span>
-      </mat-card>
+      @if (userRoleNeedsUpdated(projectDoc.id) ?? false) {
+        <app-notice id="message-permission-needs-updated" icon="info" type="info">
+          <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}:
+          {{
+            currentUserRole(projectDoc.id) === "pt_translator" || currentUserRole(projectDoc.id) === "pt_administrator"
+              ? t("update_role")
+              : t("contact_admin_update_role")
+          }}
+          @if (
+            currentUserRole(projectDoc.id) === "pt_translator" || currentUserRole(projectDoc.id) === "pt_administrator"
+          ) {
+            <button class="update-permissions-btn" mat-flat-button (click)="updateUserRole(projectDoc.id)">
+              {{ t("update") }}
+            </button>
+          }
+        </app-notice>
+      } @else {
+        <mat-card
+          [class.active-project]="isLastSelectedProject(projectDoc)"
+          id="user-connected-project-card-{{ projectDoc.data?.paratextId }}"
+          [attr.data-pt-project-id]="projectDoc.data?.paratextId"
+          class="user-connected-project mat-elevation-z4"
+          appRouterLink="/projects/{{ projectDoc.id }}"
+          matRipple
+        >
+          <span class="project-name">
+            <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}
+          </span>
+          <span class="project-description">
+            {{ projectTypeDescription(projectDoc) }}
+          </span>
+        </mat-card>
+      }
     }
     @if (initialLoadingSFProjects) {
       <mat-card id="sf-loading-card" class="loading-card">

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -377,6 +377,7 @@
     "access_another_project": "If you don't see a project you are expecting, you may need to receive an invitation to the project. Or, if you use Paratext, you can log out and log back in using 'Log in with Paratext', and connect to your Paratext projects.",
     "connect_a_project_to_get_started": "Connect a project to get started",
     "connected": "Connected",
+    "contact_admin_update_role": "Please contact your project administrator to sync this project.",
     "dbl_resource": "Digital Bible Library resource",
     "dbl_resources": "Digital Bible Library resources",
     "drafting": "Drafting",
@@ -392,7 +393,9 @@
     "offline": "You will need to connect to the internet to get started with a project.",
     "offline-accessible": "Offline Access",
     "open": "Open",
-    "problem_getting_pt_list": "There was a problem getting the list of available Paratext projects to connect to. If this continues to happen, and logging out and back in does not fix the problem, please report the issue for help."
+    "problem_getting_pt_list": "There was a problem getting the list of available Paratext projects to connect to. If this continues to happen, and logging out and back in does not fix the problem, please report the issue for help.",
+    "update": "Update",
+    "update_role": "Paratext role needs updated."
   },
   "roles": {
     "sf_community_checker": "Community Checker"

--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -46,6 +46,11 @@ public class ParatextProject
     public string? ProjectId { get; init; }
 
     /// <summary>
+    /// The role of the user in the project.
+    /// </summary>
+    public string? ProjectUserRole { get; init; }
+
+    /// <summary>
     /// If the requesting user has access to the PT project, but not yet to a corresponding SF project, and has
     /// permission to connect an SF project to the PT project. The SF project may or may not yet already exist.
     /// </summary>
@@ -55,6 +60,11 @@ public class ParatextProject
     /// If the requesting user has access to both the PT project and the corresponding SF project.
     /// </summary>
     public bool IsConnected { get; init; }
+
+    /// <summary>
+    /// If the user's role in the project needs to be updated.
+    /// </summary>
+    public bool UserRoleNeedsUpdated { get; init; }
 
     /// <summary>
     /// A descriptive string of object's properties, for debugging.

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2266,10 +2266,14 @@ public class ParatextService : DisposableBase, IParatextService
 
             bool sfProjectExists = correspondingSfProject != null;
             bool sfUserIsOnSfProject = correspondingSfProject?.UserRoles.ContainsKey(userSecret.Id) ?? false;
-            bool adminOnPtProject =
-                remotePtProject.SourceUsers.GetRole(GetParatextUsername(userSecret)) == UserRoles.Administrator;
+            UserRoles ptUserRole = remotePtProject.SourceUsers.GetRole(GetParatextUsername(userSecret));
+            bool adminOnPtProject = ptUserRole == UserRoles.Administrator;
             bool ptProjectIsConnectable =
                 (sfProjectExists && !sfUserIsOnSfProject) || (!sfProjectExists && adminOnPtProject);
+            bool updateUserRole =
+                sfProjectExists
+                && sfUserIsOnSfProject
+                && ConvertFromUserRole(ptUserRole) != correspondingSfProject.UserRoles[userSecret.Id];
 
             // On SF Live server, many users have projects without corresponding project metadata.
             // If this happens, default to using the project's short name
@@ -2293,6 +2297,8 @@ public class ParatextService : DisposableBase, IParatextService
                     ProjectId = correspondingSfProject?.Id,
                     IsConnectable = ptProjectIsConnectable,
                     IsConnected = sfProjectExists && sfUserIsOnSfProject,
+                    UserRoleNeedsUpdated = updateUserRole,
+                    ProjectUserRole = ConvertFromUserRole(ptUserRole),
                 }
             );
         }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -155,7 +155,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
     )
     {
         TModel project = await GetProjectAsync(projectId);
-        if (!systemRoles.Contains(SystemRole.SystemAdmin) && !IsProjectAdmin(project, curUserId))
+        if (!systemRoles.Contains(SystemRole.SystemAdmin) && !IsProjectAdmin(project, curUserId, projectRole))
             throw new ForbiddenException();
 
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
@@ -321,8 +321,9 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
 
     protected bool IsOnProject(TModel project, string userId) => project.UserRoles.ContainsKey(userId);
 
-    protected bool IsProjectAdmin(TModel project, string userId) =>
-        project.UserRoles.TryGetValue(userId, out string role) && role == ProjectAdminRole;
+    protected bool IsProjectAdmin(TModel project, string userId, string projectRole = null) =>
+        project.UserRoles.TryGetValue(userId, out string role) && role == ProjectAdminRole
+        || projectRole == ProjectAdminRole;
 
     protected string GetAudioDir(string projectId) => Path.Combine(SiteOptions.Value.SiteDir, "audio", projectId);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Projects now display notifications prompting users to update their role when necessary.
  - A new update button allows users to quickly synchronize their project roles.
  - Interface labels and messages have been refined to provide clearer guidance on role updates.
  - Overall, the project management view has been enhanced for improved clarity and user control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->