### PR TITLE
SF-3089 Show message when draft could not be added to the chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, OnChanges, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { translate } from '@ngneat/transloco';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DeltaOperation } from 'rich-text';
@@ -22,6 +23,7 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { DialogService } from 'xforge-common/dialog.service';
 import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
+import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { isString } from '../../../../type-utils';
@@ -67,7 +69,8 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     readonly fontService: FontService,
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
-    readonly onlineStatusService: OnlineStatusService
+    readonly onlineStatusService: OnlineStatusService,
+    private readonly noticeService: NoticeService
   ) {}
 
   ngOnChanges(): void {
@@ -169,9 +172,13 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       }
     }
 
-    await this.draftHandlingService.applyChapterDraftAsync(this.textDocId!, this.draftDelta);
-    this.isDraftApplied = true;
-    this.userAppliedDraft = true;
+    try {
+      await this.draftHandlingService.applyChapterDraftAsync(this.textDocId!, this.draftDelta);
+      this.isDraftApplied = true;
+      this.userAppliedDraft = true;
+    } catch {
+      this.noticeService.showError(translate('editor_draft_tab.error_applying_draft'));
+    }
   }
 
   private setInitialState(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -20,7 +20,9 @@ import {
   throttleTime
 } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { CommandError } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -70,7 +72,8 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
     readonly onlineStatusService: OnlineStatusService,
-    private readonly noticeService: NoticeService
+    private readonly noticeService: NoticeService,
+    private errorReportingService: ErrorReportingService
   ) {}
 
   ngOnChanges(): void {
@@ -176,8 +179,13 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       await this.draftHandlingService.applyChapterDraftAsync(this.textDocId!, this.draftDelta);
       this.isDraftApplied = true;
       this.userAppliedDraft = true;
-    } catch {
+    } catch (err) {
       this.noticeService.showError(translate('editor_draft_tab.error_applying_draft'));
+      if (err instanceof CommandError && err.message.includes('504 Gateway Timeout')) return;
+      this.errorReportingService.silentError(
+        'Error applying a draft to a chapter',
+        ErrorReportingService.normalizeError(err)
+      );
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -290,6 +290,7 @@
     "click_book_to_preview": "Click a book below to preview the draft and add it to your project.",
     "draft_indicator_applied": "Added",
     "draft_legacy_warning": "We have updated our drafting functionality. You can take advantage of this by [link:generateDraftUrl]generating a new draft[/link].",
+    "error_applying_draft": "Failed to add the draft to the project. Try again later.",
     "no_draft_notice": "{{ bookChapterName }} has no draft.",
     "offline_notice": "Auto draft is not available offline.",
     "overwrite": "Adding the draft will overwrite the current chapter. Are you sure you want to continue?",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling during the draft submission process with improved user notifications. Now, if a network timeout or generic error occurs, users receive clear, concise messages.
  - Introduced updated messaging to inform users when a draft cannot be added.

- **Bug Fixes**
  - Refined state management to ensure that unsuccessful draft submissions are accurately indicated as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->