### PR TITLE
SF-3757 Add simplified draft config page as experimental feature

### DIFF
--- a/scripts/db_tools/parse-version.ts
+++ b/scripts/db_tools/parse-version.ts
@@ -33,16 +33,17 @@ class ParseVersion {
     'Stillness (non-distracting progress indicators)',
     'Use In-Process Machine for Suggestions',
     'Use Serval for Suggestions',
-    'Use Echo for Pre-Translation Drafting',
+    'Allow Echo for Pre-Translation Drafting',
     'Allow Fast Pre-Translation Training',
     'Upload Paratext Zip Files for Pre-Translation Drafting',
     'Allow mixing in an additional training source',
     'Updated Learning Rate For Serval',
-    'Dark Mode',
+    'Dark mode',
     'Enable Lynx insights',
     'Preview new draft history interface',
     'USFM Format',
-    'Show in-app draft signup form instead of external link'
+    'Show in-app draft signup form instead of external link',
+    'Show new configure sources page'
   ];
 
   constructor() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -149,6 +149,11 @@
           <button mat-menu-item appRouterLink="/projects" id="project-home-link">
             <mat-icon>home</mat-icon> {{ "my_projects.my_projects" | transloco }}
           </button>
+          @if (experimentalFeatures.showExperimentalFeaturesInMenu) {
+            <button mat-menu-item (click)="openExperimentalFeaturesDialog()">
+              <mat-icon>science</mat-icon> {{ t("experimental_features") }}
+            </button>
+          }
           @if (featureFlags.showDeveloperTools.enabled) {
             <button mat-menu-item [matMenuTriggerFor]="appearanceMenu">
               <mat-icon>palette</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -28,6 +28,8 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DiagnosticOverlayService } from 'xforge-common/diagnostic-overlay.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { ExperimentalFeaturesDialogComponent } from 'xforge-common/experimental-features/experimental-features-dialog.component';
+import { ExperimentalFeaturesService } from 'xforge-common/experimental-features/experimental-features.service';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { FeatureFlagsDialogComponent } from 'xforge-common/feature-flags/feature-flags-dialog.component';
@@ -138,6 +140,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly themeService: ThemeService,
     private readonly fontService: FontService,
     onlineStatusService: OnlineStatusService,
+    readonly experimentalFeatures: ExperimentalFeaturesService,
     private destroyRef: DestroyRef
   ) {
     super(noticeService);
@@ -476,6 +479,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   openFeatureFlagDialog(): void {
     this.dialogService.openMatDialog(FeatureFlagsDialogComponent);
+  }
+
+  openExperimentalFeaturesDialog(): void {
+    this.dialogService.openMatDialog(ExperimentalFeaturesDialogComponent);
   }
 
   openDiagnosticOverlay(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.routes.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.routes.ts
@@ -31,6 +31,7 @@ import { DraftGenerationComponent } from './translate/draft-generation/draft-gen
 import { DraftOnboardingFormComponent } from './translate/draft-generation/draft-signup-form/draft-onboarding-form.component';
 import { DraftSourcesComponent } from './translate/draft-generation/draft-sources/draft-sources.component';
 import { DraftUsfmFormatComponent } from './translate/draft-generation/draft-usfm-format/draft-usfm-format.component';
+import { NewConfigureSourcesComponent } from './translate/draft-generation/new-configure-sources/new-configure-sources.component';
 import { EditorComponent } from './translate/editor/editor.component';
 import { TranslateOverviewComponent } from './translate/translate-overview/translate-overview.component';
 import { UsersComponent } from './users/users.component';
@@ -69,6 +70,12 @@ export const APP_ROUTES: Routes = [
   {
     path: 'projects/:projectId/draft-generation/sources',
     component: DraftSourcesComponent,
+    canActivate: [NmtDraftAuthGuard],
+    canDeactivate: [DraftNavigationAuthGuard]
+  },
+  {
+    path: 'projects/:projectId/draft-generation/new-configure-sources',
+    component: NewConfigureSourcesComponent,
     canActivate: [NmtDraftAuthGuard],
     canDeactivate: [DraftNavigationAuthGuard]
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -211,13 +211,18 @@
                     {{ t("generate_draft_button") }}
                   </button>
                   @if (hasConfigureSourcePermission) {
-                    <button mat-button data-test-id="configure-button" [routerLink]="['sources']">
+                    <button mat-button data-test-id="configure-button" [routerLink]="configureSourcesPath">
                       <mat-icon>settings</mat-icon>
                       {{ t("configure_sources") }}
                     </button>
                   }
                 } @else if (hasConfigureSourcePermission) {
-                  <button mat-flat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
+                  <button
+                    mat-flat-button
+                    data-test-id="configure-button"
+                    color="primary"
+                    [routerLink]="configureSourcesPath"
+                  >
                     <mat-icon>settings</mat-icon>
                     {{ t("configure_sources") }}
                   </button>
@@ -294,7 +299,7 @@
           <mat-icon>add</mat-icon> {{ t("generate_new_draft") }}
         </button>
         @if (hasConfigureSourcePermission) {
-          <button mat-button data-test-id="configure-button" [routerLink]="['sources']">
+          <button mat-button data-test-id="configure-button" [routerLink]="configureSourcesPath">
             <mat-icon>settings</mat-icon> {{ t("configure_sources") }}
           </button>
         }
@@ -306,7 +311,7 @@
         This first check regards what leads up to the first configure button. -->
         @if (!isGenerationSupported || isDraftInProgress(draftJob) || hasAnyCompletedBuild) {
           @if (draftEnabled && isOnline) {
-            <button mat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
+            <button mat-button data-test-id="configure-button" color="primary" [routerLink]="configureSourcesPath">
               <mat-icon>settings</mat-icon> {{ t("configure_sources") }}
             </button>
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -161,7 +161,8 @@ describe('DraftGenerationComponent', () => {
       mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>({
         newDraftHistory: createTestFeatureFlag(false),
         usfmFormat: createTestFeatureFlag(false),
-        inAppDraftSignupForm: createTestFeatureFlag(true)
+        inAppDraftSignupForm: createTestFeatureFlag(true),
+        newConfigureSourcesPage: createTestFeatureFlag(false)
       });
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -342,6 +342,13 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     );
   }
 
+  get configureSourcesPath(): string[] {
+    const projectId = this.activatedProject.projectId;
+    if (projectId == null) return [];
+    const minorPath = this.featureFlags.newConfigureSourcesPage.enabled ? 'new-configure-sources' : 'sources';
+    return ['/projects', projectId, 'draft-generation', minorPath];
+  }
+
   async generateDraftClicked(): Promise<void> {
     if (this.formattingOptionsRequired) {
       const dialogRef = this.dialogService.openGenericDialog({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -97,7 +97,7 @@
             [placeholder]="projectPlaceholder(source)"
           ></app-project-select>
         }
-        <p class="no-bottom-margin">
+        <p>
           {{ t("training_files_description", { sourceLanguageDisplayName, targetLanguageDisplayName }) }}
         </p>
         <div class="training-files">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
@@ -239,7 +239,3 @@ strong {
 .training-files {
   margin-bottom: 30px;
 }
-
-.no-bottom-margin {
-  margin-bottom: 0;
-}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.html
@@ -1,0 +1,211 @@
+<ng-container *transloco="let t; read: 'draft_sources'">
+  <h1>{{ t("configure_draft_sources") }}</h1>
+
+  <app-notice class="experimental-notice" type="primary" mode="fill-dark" icon="science">
+    This is an experimental simplified page for configuring sources. Please
+    <a href="mailto:{{ issueEmail }}" target="_blank">leave us feedback</a> on how it works for you.
+  </app-notice>
+
+  <mat-expansion-panel class="introduction">
+    <mat-expansion-panel-header>How to configure draft sources</mat-expansion-panel-header>
+    <p>
+      Generating a draft requires two steps. First we need to teach a model how to translate from one language into
+      another. The 'from language' is also known as the 'Source', and the 'to language' is also known as the 'Target'.
+    </p>
+    <p>
+      Source languages already known to the model, or closely related to the Target language usually work best.
+      <a href="#" (click)="showModelLanguages($event)">Here is a list of the languages that the model knows already.</a>
+    </p>
+    <p>
+      The current project <strong>{{ currentProjectShortName }}</strong> will be used to train a model that can
+      translate into <strong>{{ targetLanguageDisplayName }}</strong
+      >.
+    </p>
+    <h3>Choosing Source Projects for training the model</h3>
+    <p>
+      Choose one or two texts in the 'Source Language'. Sometimes choosing a Back Translation improves the model. It is
+      worth testing with and without the Back Translation to see which setting gives you the best results.
+    </p>
+    <p>
+      There is an option to include other translation examples in training by uploading a spreadsheet with two columns.
+      The first column contains the Source text and the second column contains its translation in the Target language.
+    </p>
+
+    <h3>Choosing a Drafting Source</h3>
+    <p>
+      The model will create drafts by translating books from the 'Drafting Source Project'. It is rare that the model
+      will give useful results if the Drafting Source Project isn't included in the Source projects for training the
+      model.
+    </p>
+
+    <p>
+      You will be able to look at the drafts before you need to decide how to use them. Scripture Forge will not
+      automatically add the generated drafts to any project. They will only be available in Scripture Forge until you
+      add them to a project.
+    </p>
+
+    <p><a [href]="urls.configuringSources" target="_blank">More help on Configuring Sources</a></p>
+  </mat-expansion-panel>
+
+  <div class="overview">
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>{{ "new_configure_sources.train_language_model" | transloco }}</mat-card-title>
+      </mat-card-header>
+      <mat-card-content class="training-data">
+        <div class="sources">
+          <h3>{{ t("overview_reference") }} {{ parentheses(referenceLanguageDisplayName) }}</h3>
+
+          <div>{{ t("select_primary_reference") }}</div>
+          @for (source of trainingSources; track $index) {
+            <app-project-select
+              [isDisabled]="loading || !appOnline"
+              [projects]="projects"
+              [resources]="resources"
+              [nonSelectableProjects]="nonSelectableProjects"
+              [value]="source?.paratextId"
+              [hiddenParatextIds]="getHiddenParatextIds(trainingSources, source?.paratextId)"
+              (valueChange)="sourceSelected(trainingSources, $index, $event)"
+              [placeholder]="projectPlaceholder(source)"
+            ></app-project-select>
+          }
+
+          @if (allowAddingATrainingSource) {
+            <div>{{ t("some_projects_use_back_translation") }}</div>
+            <button
+              mat-button
+              (click)="trainingSources.push(undefined); $event.preventDefault()"
+              class="add-another-project"
+            >
+              <mat-icon>add</mat-icon> {{ t("add_another_reference_project") }}
+            </button>
+          }
+        </div>
+        <span class="arrow mirror-rtl"><mat-icon>arrow_right_alt</mat-icon></span>
+        <div class="targets">
+          <h3>{{ t("overview_translated_project") }} {{ parentheses(targetLanguageDisplayName) }}</h3>
+          <div>
+            @for (portion of i18n.interpolateVariables("draft_sources.project_always_used"); track $index) {
+              @if (portion.id === "currentProjectShortName") {
+                <strong>{{ currentProjectShortName }}</strong>
+              }
+              <!-- prettier-ignore -->
+              @else {{{ portion.text }}}
+            }
+            <!-- Select here any other projects to be used on the target side. All of these should be in the language of the target (<strong>{{ targetLanguageDisplayName }}</strong>). -->
+          </div>
+          @for (source of trainingTargets; track $index) {
+            <app-project-select
+              [isDisabled]="true"
+              [projects]="projects"
+              [resources]="resources"
+              [nonSelectableProjects]="nonSelectableProjects"
+              [value]="source?.paratextId"
+              [hiddenParatextIds]="getHiddenParatextIds(trainingTargets, source?.paratextId)"
+              [placeholder]="projectPlaceholder(source)"
+            ></app-project-select>
+          }
+          <div>
+            {{ t("training_files_description", { sourceLanguageDisplayName, targetLanguageDisplayName }) }}
+          </div>
+          <div class="training-files">
+            <app-training-data-multi-select
+              [availableTrainingData]="availableTrainingFiles"
+              (trainingDataSelect)="onTrainingDataSelect($event)"
+            ></app-training-data-multi-select>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>
+          {{ "new_configure_sources.generate_a_draft_from_the_language_model" | transloco }}
+        </mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="translation-data">
+          <h3>{{ t("overview_source") }} {{ parentheses(sourceLanguageDisplayName) }}</h3>
+          <div>{{ t("select_project_to_translate") }}</div>
+          @for (source of draftingSources; track $index) {
+            <app-project-select
+              [isDisabled]="loading || !appOnline"
+              [projects]="projects"
+              [resources]="resources"
+              [nonSelectableProjects]="nonSelectableProjects"
+              [value]="source?.paratextId"
+              [hiddenParatextIds]="getHiddenParatextIds(draftingSources, source?.paratextId)"
+              (valueChange)="sourceSelected(draftingSources, $index, $event)"
+              [placeholder]="projectPlaceholder(source)"
+            ></app-project-select>
+          }
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <app-language-codes-confirmation
+    class="confirm-language-codes"
+    [sources]="draftSourcesAsArray"
+    [clearCheckbox]="clearLanguageCodeConfirmationCheckbox"
+    (messageIfUserTriesToContinue)="languageCodeConfirmationMessageIfUserTriesToContinue = $event"
+  ></app-language-codes-confirmation>
+
+  <div class="component-footer">
+    @if (!appOnline) {
+      <mat-error id="offline-message">
+        {{ t("offline_message") }}
+      </mat-error>
+    }
+    <div class="page-actions">
+      <button mat-button (click)="cancel()"><mat-icon>close</mat-icon>{{ t("cancel") }}</button>
+      <button id="save_button" mat-flat-button color="primary" (click)="save()" [disabled]="!appOnline">
+        <mat-icon>check</mat-icon>{{ t("save_and_sync") }}
+      </button>
+    </div>
+  </div>
+
+  @if (getControlState("projectSettings") != null) {
+    <mat-card class="saving">
+      <mat-card-header>
+        <mat-card-title>{{ t("saving_draft_sources") }}</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="saving-indicator">
+          @if (getControlState("projectSettings") === ElementState.Submitting) {
+            <mat-spinner [diameter]="24" color="primary"></mat-spinner> {{ t("saving") }}
+          } @else if (getControlState("projectSettings") === ElementState.Submitted) {
+            <mat-icon class="success">checkmark</mat-icon> {{ t("all_changes_saved") }}
+          } @else {
+            <mat-icon class="failure">error</mat-icon> {{ t("failed_to_save_changes") }}
+          }
+        </div>
+        @for (entry of syncStatus | keyvalue; track entry.key) {
+          <div>
+            @if (entry.value.knownToBeOnSF) {
+              @if (entry.value.isSyncing) {
+                <mat-spinner [diameter]="24"></mat-spinner> {{ entry.value.shortName }} - {{ t("state_syncing") }}
+              } @else {
+                @if (entry.value.lastSyncSuccessful) {
+                  <mat-icon class="success">check</mat-icon> {{ entry.value.shortName }} -
+                  {{ t("state_sync_successful") }}
+                } @else {
+                  <mat-icon class="failure">error</mat-icon> {{ entry.value.shortName }} -
+                  {{ t("state_sync_failed") }}
+                }
+              }
+            } @else {
+              <mat-spinner [diameter]="24"></mat-spinner> {{ entry.value.shortName }} - {{ t("state_connecting") }}
+            }
+          </div>
+        }
+      </mat-card-content>
+      @if (allProjectsSavedAndSynced || getControlState("projectSettings") === ElementState.Error) {
+        <mat-card-actions align="end">
+          <button mat-button (click)="navigateToDrafting()"><mat-icon>close</mat-icon> {{ t("close") }}</button>
+        </mat-card-actions>
+      }
+    </mat-card>
+  }
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.scss
@@ -1,0 +1,135 @@
+:host {
+  display: grid;
+  grid-column-gap: 2em;
+  grid-row-gap: 1em;
+  align-items: start;
+  grid-template-areas: 'title' 'experimental-notice' 'introduction' 'overview' 'confirmation' 'footer';
+  max-width: 130em;
+}
+
+.experimental-notice {
+  grid-area: experimental-notice;
+}
+
+h1 {
+  grid-area: title;
+  margin: 0;
+}
+
+h2,
+h3,
+strong {
+  font-weight: 500;
+}
+
+.introduction {
+  grid-area: introduction;
+
+  * {
+    letter-spacing: initial;
+  }
+
+  h3 {
+    margin-bottom: 0em;
+  }
+  h3 + p {
+    margin-top: 0.25em;
+  }
+}
+
+.overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  grid-area: overview;
+}
+
+.overview mat-card-content {
+  display: flex;
+  gap: 1em;
+  padding-top: 1em;
+}
+
+.arrow mat-icon {
+  scale: 2;
+}
+
+.arrow {
+  display: flex;
+  align-items: center;
+}
+
+.sources,
+.targets,
+.translation-data {
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  flex-basis: 45%;
+
+  > p:first-child {
+    margin-top: 0;
+  }
+}
+
+.overview h3 {
+  margin: 0;
+}
+
+#offline-message {
+  display: flex;
+  justify-self: flex-end;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.page-actions {
+  display: flex;
+  gap: 0.5em;
+  justify-content: flex-end;
+}
+
+.add-another-project {
+  margin-bottom: 1em;
+}
+
+.component-footer {
+  grid-area: footer;
+}
+
+.confirm-language-codes {
+  grid-area: confirmation;
+}
+
+:host:has(.saving) > :not(.saving):not(h1) {
+  display: none;
+}
+
+.saving {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  width: auto;
+  margin-inline: auto;
+}
+
+.saving .mat-mdc-card-content {
+  display: flex;
+  gap: 1em;
+  flex-direction: column;
+  padding-block: 1em;
+
+  & > * {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+  }
+}
+
+.success {
+  color: green;
+}
+.failure {
+  color: var(--sf-error-color);
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.spec.ts
@@ -1,0 +1,872 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
+import { of, Subject } from 'rxjs';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { AuthService } from 'xforge-common/auth.service';
+import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
+import { DialogService } from 'xforge-common/dialog.service';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { ExternalUrlService } from 'xforge-common/external-url.service';
+import { FileService } from 'xforge-common/file.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
+import { SFUserProjectsService } from 'xforge-common/user-projects.service';
+import { hasData, notNull, WithData } from '../../../../type-utils';
+import { ParatextProject } from '../../../core/models/paratext-project';
+import { SelectableProjectWithLanguageCode } from '../../../core/models/selectable-project';
+import { SFProjectDoc } from '../../../core/models/sf-project-doc';
+import { SFProjectSettings } from '../../../core/models/sf-project-settings';
+import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
+import { ParatextService } from '../../../core/paratext.service';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { DraftSource, DraftSourcesAsArrays } from '../draft-source';
+import { translateSourceToSelectableProjectWithLanguageTag } from '../draft-utils';
+import { TrainingDataService } from '../training-data/training-data.service';
+import { NewConfigureSourcesComponent, sourceArraysToSettingsChange } from './new-configure-sources.component';
+
+/** This interface allows specification of a project using multiple types at once, to help the spec provide the
+ * different types required by the component. */
+interface MultiTypeProjectDescription {
+  paratextProject: ParatextProject;
+  selectableProjectWithLanguageCode: SelectableProjectWithLanguageCode;
+  projectType: 'project' | 'resource';
+  /** sfProjectDoc may be undefined if the project is not in SF. */
+  sfProjectDoc: WithData<SFProjectDoc> | undefined;
+  /** translateSource may be undefined if the project is not in SF. */
+  translateSource: TranslateSource | undefined;
+}
+
+const mockedParatextService = mock(ParatextService);
+const mockedActivatedProjectService = mock(ActivatedProjectService);
+const mockedNoticeService = mock(NoticeService);
+const mockedI18nService = mock(I18nService);
+const mockedSFProjectService = mock(SFProjectService);
+const mockedSFUserProjectsService = mock(SFUserProjectsService);
+const mockedAuthService = mock(AuthService);
+const mockedDialogService = mock(DialogService);
+const mockTrainingDataService = mock(TrainingDataService);
+const mockedFileService = mock(FileService);
+
+const mockTrainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery);
+const trainingDataQueryLocalChanges$: Subject<void> = new Subject<void>();
+when(mockTrainingDataQuery.localChanges$).thenReturn(trainingDataQueryLocalChanges$);
+when(mockTrainingDataQuery.ready$).thenReturn(of(true));
+when(mockTrainingDataQuery.remoteChanges$).thenReturn(of());
+when(mockTrainingDataQuery.remoteDocChanges$).thenReturn(of());
+
+describe('NewConfigureSourcesComponent', () => {
+  configureTestingModule(() => ({
+    imports: [getTestTranslocoModule()],
+    providers: [
+      provideTestOnlineStatus(),
+      provideTestRealtime(SF_TYPE_REGISTRY),
+      { provide: ParatextService, useMock: mockedParatextService },
+      { provide: ActivatedProjectService, useMock: mockedActivatedProjectService },
+      { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: I18nService, useMock: mockedI18nService },
+      { provide: SFProjectService, useMock: mockedSFProjectService },
+      { provide: SFUserProjectsService, useMock: mockedSFUserProjectsService },
+      { provide: AuthService, useMock: mockedAuthService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+      { provide: DialogService, useMock: mockedDialogService },
+      { provide: TrainingDataService, useMock: mockTrainingDataService },
+      { provide: ErrorReportingService, useMock: mock(ErrorReportingService) },
+      { provide: FileService, useMock: mockedFileService },
+      { provide: ExternalUrlService, useClass: ExternalUrlService }
+    ]
+  }));
+
+  let overlayContainer: OverlayContainer;
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+  });
+  afterEach(() => {
+    // Prevents 'Error: Test did not clean up its overlay container content.'
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('loads projects and resources on init', fakeAsync(() => {
+    const env = new TestEnvironment();
+    verify(mockedParatextService.getProjects()).once();
+    verify(mockedParatextService.getResources()).once();
+    expect(env.component.projects).toBeDefined();
+    expect(env.component.resources).toBeDefined();
+  }));
+
+  it('suppresses network errors', fakeAsync(() => {
+    const env = new TestEnvironment({ projectLoadSuccessful: false });
+    tick();
+    env.fixture.detectChanges();
+    expect(env.component.projects).toBeUndefined();
+  }));
+
+  it('loads projects and resources when returning online', fakeAsync(() => {
+    const env = new TestEnvironment({ isOnline: false });
+    verify(mockedParatextService.getProjects()).never();
+    verify(mockedParatextService.getResources()).never();
+    expect(env.component.projects).toBeUndefined();
+    expect(env.component.resources).toBeUndefined();
+
+    // Simulate going online
+    env.testOnlineStatusService.setIsOnline(true);
+    tick();
+    env.fixture.detectChanges();
+    verify(mockedParatextService.getProjects()).once();
+    verify(mockedParatextService.getResources()).once();
+    expect(env.component.projects).toBeDefined();
+    expect(env.component.resources).toBeDefined();
+  }));
+
+  describe('save', () => {
+    it('should save the settings', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      expect(env.component['changesMade']).toBe(false);
+      env.clickLanguageCodesConfirmationCheckbox();
+      // Suppose the user loads up the sources configuration page, changes no projects, and clicks Save. The settings
+      // change request will just correspond to what the project already has for its settings.
+      const expectedSettingsChangeRequest: SFProjectSettings = {
+        draftingSourcesParatextIds: env.activatedProjectDoc.data!.translateConfig.draftConfig.draftingSources.map(
+          s => s.paratextId
+        ),
+        trainingSourcesParatextIds: env.activatedProjectDoc.data!.translateConfig.draftConfig.trainingSources.map(
+          s => s.paratextId
+        ),
+        additionalTrainingDataFiles:
+          env.activatedProjectDoc.data!.translateConfig.draftConfig.lastSelectedTrainingDataFiles
+      };
+
+      // No unsaved changes
+      env.component.confirmLeave();
+      tick();
+      env.fixture.detectChanges();
+      verify(mockedDialogService.confirm(anything(), anything(), anything())).never();
+
+      // SUT
+      env.component.save();
+      tick();
+      verify(mockedSFProjectService.onlineUpdateSettings(env.activatedProjectDoc.id, anything())).once();
+      const actualSettingsChangeRequest: SFProjectSettings = capture(
+        mockedSFProjectService.onlineUpdateSettings
+      ).last()[1];
+      expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+    }));
+
+    it('clearing second training source works', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+      expect(env.component['changesMade']).toBe(false);
+
+      // Suppose the user loads up the page, clears the second training/reference project box, and clicks Save. The
+      // settings change request will show a requested change for unsetting the additional-training-source.
+      const expectedSettingsChangeRequest: SFProjectSettings = {
+        draftingSourcesParatextIds: env.activatedProjectDoc.data!.translateConfig.draftConfig.draftingSources.map(
+          s => s.paratextId
+        ),
+        trainingSourcesParatextIds: [
+          env.activatedProjectDoc.data!.translateConfig.draftConfig.trainingSources[0].paratextId
+        ],
+        additionalTrainingDataFiles:
+          env.activatedProjectDoc.data!.translateConfig.draftConfig.lastSelectedTrainingDataFiles
+      };
+
+      // Remove the second training source.
+      env.component.trainingSources.pop();
+      // Confirm that we have 1 training source.
+      expect(env.component.trainingSources.length).toEqual(1);
+      env.component['changesMade'] = true;
+      // user is prompted if user is navigating away
+      env.component.confirmLeave();
+      tick();
+      env.fixture.detectChanges();
+      verify(mockedDialogService.confirm(anything(), anything(), anything())).once();
+
+      // SUT
+      env.component.save();
+      tick();
+      verify(mockedSFProjectService.onlineUpdateSettings(env.activatedProjectDoc.id, anything())).once();
+      const actualSettingsChangeRequest: SFProjectSettings = capture(
+        mockedSFProjectService.onlineUpdateSettings
+      ).last()[1];
+      expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+    }));
+
+    it('clearing first training source works', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      expect(env.component['changesMade']).toBe(false);
+      env.clickLanguageCodesConfirmationCheckbox();
+
+      // Suppose the user comes to the page, leaves the second reference/training project selection alone, and clears
+      // the first reference/training project selection. Let's respond by clearing the additional-training-source, and
+      // setting the first-training-source to the remaining reference/training project that is still specified.
+      const expectedSettingsChangeRequest: SFProjectSettings = {
+        draftingSourcesParatextIds: env.activatedProjectDoc.data!.translateConfig.draftConfig.draftingSources.map(
+          s => s.paratextId
+        ),
+        trainingSourcesParatextIds: [
+          env.activatedProjectDoc.data!.translateConfig.draftConfig.trainingSources[1].paratextId
+        ],
+        additionalTrainingDataFiles:
+          env.activatedProjectDoc.data!.translateConfig.draftConfig.lastSelectedTrainingDataFiles
+      };
+
+      // Remove the first training source.
+      env.component.trainingSources[0] = undefined;
+      // Confirm that we have 1 other training source.
+      expect(env.component.trainingSources[1]).not.toBeNull();
+      env.fixture.detectChanges();
+      tick();
+
+      // SUT
+      env.component.save();
+      tick();
+      verify(mockedSFProjectService.onlineUpdateSettings(env.activatedProjectDoc.id, anything())).once();
+      const actualSettingsChangeRequest: SFProjectSettings = capture(
+        mockedSFProjectService.onlineUpdateSettings
+      ).last()[1];
+      expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+    }));
+
+    it('fails to save and sync', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+
+      // Remove the second training source.
+      env.component.trainingSources.pop();
+      // Confirm that we have 1 training source.
+      expect(env.component.trainingSources.length).toEqual(1);
+      env.fixture.detectChanges();
+      tick();
+
+      // Simulate failed response
+      when(mockedSFProjectService.onlineUpdateSettings(anything(), anything())).thenReject(
+        new CommandError(CommandErrorCode.Other, '504 Gateway Timeout')
+      );
+
+      // SUT
+      env.component.save();
+      tick();
+      verify(mockedSFProjectService.onlineUpdateSettings(env.activatedProjectDoc.id, anything())).once();
+    }));
+
+    it('can edit second source after first is cleared', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+
+      // Remove the first training source.
+      env.component.sourceSelected(env.component.trainingSources, 0, undefined);
+      // Confirm that we have 1 other training source.
+      expect(env.component.trainingSources[1]).not.toBeNull();
+      env.fixture.detectChanges();
+      tick();
+
+      // SUT
+      env.component.sourceSelected(env.component.trainingSources, 1, undefined);
+      env.fixture.detectChanges();
+      tick();
+      expect(env.component.trainingSources.length).toEqual(2);
+    }));
+
+    it('saves the selected training files', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+
+      const expectedSettingsChangeRequest: SFProjectSettings = {
+        draftingSourcesParatextIds: env.activatedProjectDoc.data!.translateConfig.draftConfig.draftingSources.map(
+          s => s.paratextId
+        ),
+        trainingSourcesParatextIds: env.activatedProjectDoc.data!.translateConfig.draftConfig.trainingSources.map(
+          s => s.paratextId
+        ),
+        additionalTrainingDataFiles: ['test1', 'test2']
+      };
+
+      env.component.onTrainingDataSelect([{ dataId: 'test1' } as TrainingData, { dataId: 'test2' } as TrainingData]);
+
+      env.component.save();
+      tick();
+      verify(mockedSFProjectService.onlineUpdateSettings(env.activatedProjectDoc.id, anything())).once();
+      const actualSettingsChangeRequest: SFProjectSettings = capture(
+        mockedSFProjectService.onlineUpdateSettings
+      ).last()[1];
+      expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+    }));
+
+    it('creates training data for added files', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+
+      const savedFile = {} as TrainingData;
+      const deletedFile: TrainingData = { dataId: 'deleted', deleted: true } as TrainingData;
+      when(mockTrainingDataQuery.docs).thenReturn([
+        { data: savedFile } as TrainingDataDoc,
+        { data: deletedFile } as TrainingDataDoc
+      ]);
+      trainingDataQueryLocalChanges$.next();
+
+      expect(env.component.availableTrainingFiles.length).toEqual(1);
+
+      const newFile = { dataId: 'test1' } as TrainingData;
+      env.component.onTrainingDataSelect([newFile]);
+      env.component.save();
+
+      verify(mockTrainingDataService.createTrainingDataAsync(newFile)).once();
+    }));
+
+    it('deletes training data for removed files', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+
+      const savedFile1 = { dataId: 'file1' } as TrainingData;
+      const savedFile2 = { dataId: 'file2' } as TrainingData;
+      const deletedFile: TrainingData = { dataId: 'deleted', deleted: true } as TrainingData;
+      when(mockTrainingDataQuery.docs).thenReturn([
+        { data: savedFile1 } as TrainingDataDoc,
+        { data: savedFile2 } as TrainingDataDoc,
+        { data: deletedFile } as TrainingDataDoc
+      ]);
+      trainingDataQueryLocalChanges$.next();
+      tick();
+
+      expect(env.component.availableTrainingFiles.length).toEqual(2);
+
+      env.component.onTrainingDataSelect([savedFile1]);
+      env.component.save();
+      tick();
+
+      verify(mockTrainingDataService.deleteTrainingDataAsync(savedFile2)).once();
+      verify(mockTrainingDataService.deleteTrainingDataAsync(savedFile1)).never();
+      verify(mockTrainingDataService.createTrainingDataAsync(anything())).never();
+    }));
+
+    it('deletes added files on discard from confirmLeave', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+      env.clickLanguageCodesConfirmationCheckbox();
+      when(mockedDialogService.confirm(anything(), anything(), anything())).thenResolve(true);
+
+      const savedFile = { dataId: 'saved_file', ownerRef: 'user01' } as TrainingData;
+      const deletedFile: TrainingData = { dataId: 'deleted', ownerRef: 'user01', deleted: true } as TrainingData;
+      when(mockTrainingDataQuery.docs).thenReturn([
+        { data: savedFile } as TrainingDataDoc,
+        { data: deletedFile } as TrainingDataDoc
+      ]);
+      trainingDataQueryLocalChanges$.next();
+      tick();
+
+      expect(env.component.availableTrainingFiles.length).toEqual(1);
+
+      const newFile = { dataId: 'new_file', ownerRef: 'user01' } as TrainingData;
+      env.component.onTrainingDataSelect([savedFile, newFile]);
+      env.component['changesMade'] = true;
+      tick();
+
+      // SUT
+      env.component.confirmLeave();
+      tick();
+
+      verify(
+        mockedFileService.deleteFile(
+          FileType.TrainingData,
+          env.activatedProjectDoc.id,
+          TrainingDataDoc.COLLECTION,
+          newFile.dataId,
+          newFile.ownerRef
+        )
+      ).once();
+      verify(
+        mockedFileService.deleteFile(
+          FileType.TrainingData,
+          env.activatedProjectDoc.id,
+          TrainingDataDoc.COLLECTION,
+          savedFile.dataId,
+          savedFile.ownerRef
+        )
+      ).never();
+      verify(mockTrainingDataService.createTrainingDataAsync(anything())).never();
+      verify(mockTrainingDataService.deleteTrainingDataAsync(anything())).never();
+    }));
+
+    it('preserves unsaved training file changes when query updates', fakeAsync(() => {
+      const env = new TestEnvironment();
+      tick();
+      env.fixture.detectChanges();
+
+      const initialFile1 = { dataId: 'file1' } as TrainingData;
+      const initialFile2 = { dataId: 'file2' } as TrainingData;
+      const deletedFile: TrainingData = { dataId: 'deleted', deleted: true } as TrainingData;
+      when(mockTrainingDataQuery.docs).thenReturn([
+        { data: initialFile1 } as TrainingDataDoc,
+        { data: initialFile2 } as TrainingDataDoc,
+        { data: deletedFile } as TrainingDataDoc
+      ]);
+      trainingDataQueryLocalChanges$.next();
+      tick();
+
+      expect(env.component.availableTrainingFiles).toEqual([initialFile1, initialFile2]);
+      expect(env.component['savedTrainingFiles']).toEqual([initialFile1, initialFile2]);
+
+      // User removes a file and adds a new one
+      const addedFile = { dataId: 'added_file' } as TrainingData;
+      env.component.onTrainingDataSelect([initialFile2, addedFile]);
+      tick();
+
+      expect(env.component.availableTrainingFiles).toEqual([initialFile2, addedFile]);
+
+      // Another client updates the query
+      const remoteFile = { dataId: 'remote_file' } as TrainingData;
+      const remoteDeletedFile: TrainingData = { dataId: 'remote_deleted', deleted: true } as TrainingData;
+      when(mockTrainingDataQuery.docs).thenReturn([
+        { data: initialFile1 } as TrainingDataDoc,
+        { data: initialFile2 } as TrainingDataDoc,
+        { data: remoteFile } as TrainingDataDoc,
+        { data: remoteDeletedFile } as TrainingDataDoc
+      ]);
+      trainingDataQueryLocalChanges$.next();
+      tick();
+
+      // The user's unsaved changes should be preserved
+      expect(env.component.availableTrainingFiles.map(f => f.dataId).sort()).toEqual(
+        ['added_file', 'file2', 'remote_file'].sort()
+      );
+      expect(env.component['savedTrainingFiles']!.map(f => f.dataId).sort()).toEqual(
+        ['file1', 'file2', 'remote_file'].sort()
+      );
+    }));
+  });
+
+  describe('sourceArraysToSettingsChange', () => {
+    const currentProjectParatextId = 'project01';
+    const mockProject1: DraftSource = {
+      paratextId: 'pt01',
+      name: 'Project 1',
+      shortName: 'PRJ1',
+      projectRef: '',
+      writingSystem: { tag: 'en' },
+      texts: []
+    };
+    const mockProject2: DraftSource = {
+      paratextId: 'pt02',
+      name: 'Project 2',
+      shortName: 'PRJ2',
+      projectRef: '',
+      writingSystem: { tag: 'en' },
+      texts: []
+    };
+    const mockTarget: DraftSource = {
+      paratextId: currentProjectParatextId,
+      texts: [],
+      projectRef: '',
+      name: '',
+      shortName: '',
+      writingSystem: { tag: 'en' }
+    };
+    const someOtherTarget: DraftSource = {
+      paratextId: 'some-other-id',
+      texts: [],
+      projectRef: '',
+      name: '',
+      shortName: '',
+      writingSystem: { tag: 'en' }
+    };
+
+    it('should handle empty sources', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [],
+        trainingSources: [],
+        trainingTargets: [mockTarget]
+      };
+
+      const result = sourceArraysToSettingsChange(
+        sources.trainingSources,
+        sources.draftingSources,
+        sources.trainingTargets,
+        [],
+        currentProjectParatextId
+      );
+
+      expect(result).toEqual({
+        additionalTrainingDataFiles: [],
+        trainingSourcesParatextIds: [],
+        draftingSourcesParatextIds: []
+      });
+    });
+
+    it('should handle one training source', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [],
+        trainingSources: [mockProject1],
+        trainingTargets: [mockTarget]
+      };
+
+      const result = sourceArraysToSettingsChange(
+        sources.trainingSources,
+        sources.draftingSources,
+        sources.trainingTargets,
+        [],
+        currentProjectParatextId
+      );
+      expect(result).toEqual({
+        additionalTrainingDataFiles: [],
+        trainingSourcesParatextIds: [mockProject1.paratextId],
+        draftingSourcesParatextIds: []
+      });
+    });
+
+    it('should handle two training sources', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [],
+        trainingSources: [mockProject1, mockProject2],
+        trainingTargets: [mockTarget]
+      };
+
+      const result = sourceArraysToSettingsChange(
+        sources.trainingSources,
+        sources.draftingSources,
+        sources.trainingTargets,
+        [],
+        currentProjectParatextId
+      );
+      expect(result).toEqual({
+        additionalTrainingDataFiles: [],
+        trainingSourcesParatextIds: [mockProject1.paratextId, mockProject2.paratextId],
+        draftingSourcesParatextIds: []
+      });
+    });
+
+    it('should handle one drafting source', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [mockProject1],
+        trainingSources: [],
+        trainingTargets: [mockTarget]
+      };
+
+      const result = sourceArraysToSettingsChange(
+        sources.trainingSources,
+        sources.draftingSources,
+        sources.trainingTargets,
+        [],
+        currentProjectParatextId
+      );
+      expect(result).toEqual({
+        additionalTrainingDataFiles: [],
+        trainingSourcesParatextIds: [],
+        draftingSourcesParatextIds: [mockProject1.paratextId]
+      });
+    });
+
+    it('should handle full configuration', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [mockProject1],
+        trainingSources: [mockProject1, mockProject2],
+        trainingTargets: [mockTarget]
+      };
+
+      const result = sourceArraysToSettingsChange(
+        sources.trainingSources,
+        sources.draftingSources,
+        sources.trainingTargets,
+        [],
+        currentProjectParatextId
+      );
+      expect(result).toEqual({
+        additionalTrainingDataFiles: [],
+        trainingSourcesParatextIds: [mockProject1.paratextId, mockProject2.paratextId],
+        draftingSourcesParatextIds: [mockProject1.paratextId]
+      });
+    });
+
+    it('should throw error if training target is not current project', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [],
+        trainingSources: [],
+        trainingTargets: [someOtherTarget]
+      };
+
+      expect(() =>
+        sourceArraysToSettingsChange(
+          sources.trainingSources,
+          sources.draftingSources,
+          sources.trainingTargets,
+          [],
+          currentProjectParatextId
+        )
+      ).toThrow();
+    });
+
+    it('should handle undefined sources in arrays', () => {
+      const sources: DraftSourcesAsArrays = {
+        draftingSources: [],
+        trainingSources: [],
+        trainingTargets: [mockTarget]
+      };
+
+      const result = sourceArraysToSettingsChange(
+        sources.trainingSources,
+        sources.draftingSources,
+        sources.trainingTargets,
+        [],
+        currentProjectParatextId
+      );
+      expect(result).toEqual({
+        additionalTrainingDataFiles: [],
+        trainingSourcesParatextIds: [],
+        draftingSourcesParatextIds: []
+      });
+    });
+
+    it('should disable save and sync button and display offline message when offline', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.testOnlineStatusService.setIsOnline(false);
+      env.fixture.detectChanges();
+      tick();
+
+      const offlineMessage: DebugElement = env.fixture.debugElement.query(By.css('#offline-message'));
+      expect(offlineMessage).not.toBeNull();
+
+      const saveButton: DebugElement = env.fixture.debugElement.query(By.css('#save_button'));
+      expect(saveButton.attributes.disabled).toBe('true');
+    }));
+
+    it('should enable save & sync button and not display offline message when online', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.testOnlineStatusService.setIsOnline(true);
+      env.fixture.detectChanges();
+      tick();
+
+      const offlineMessage: DebugElement = env.fixture.debugElement.query(By.css('#offline-message'));
+      expect(offlineMessage).toBeNull();
+
+      const saveButton: DebugElement = env.fixture.debugElement.query(By.css('#save_button'));
+      expect(saveButton.attributes.disabled).toBeUndefined();
+    }));
+  });
+});
+
+class TestEnvironment {
+  readonly component: NewConfigureSourcesComponent;
+  readonly fixture: ComponentFixture<NewConfigureSourcesComponent>;
+  readonly realtimeService: TestRealtimeService;
+  readonly activatedProjectDoc: WithData<SFProjectDoc>;
+  readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+    OnlineStatusService
+  ) as TestOnlineStatusService;
+
+  private projectsLoaded$: Subject<void> = new Subject<void>();
+
+  constructor(
+    args: { isOnline?: boolean; projectLoadSuccessful?: boolean } = { isOnline: true, projectLoadSuccessful: true }
+  ) {
+    const userSFProjectsAndResourcesCount: number = 6;
+    const userNonSFProjectsCount: number = 3;
+    const userNonSFResourcesCount: number = 3;
+
+    this.realtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
+
+    // Make some projects and resources, already on SF, that the user has access to. These will be available as a
+    // variety of types.
+
+    const projects: MultiTypeProjectDescription[] = Array.from(
+      { length: userSFProjectsAndResourcesCount },
+      (_, i) =>
+        ({
+          id: `sf-id-${i}`,
+          data: createTestProject(
+            {
+              paratextId: `pt-id-${i}`,
+              resourceConfig:
+                i < userSFProjectsAndResourcesCount / 2
+                  ? undefined
+                  : {
+                      createdTimestamp: new Date(),
+                      manifestChecksum: '1234',
+                      permissionsChecksum: '2345',
+                      revision: 1
+                    }
+            },
+            i
+          )
+        }) as SFProjectDoc
+    )
+      .map(o => {
+        // Run it into and out of realtime service so it has fields like `remoteChanges$`.
+        this.realtimeService.addSnapshot(SFProjectDoc.COLLECTION, o);
+        return this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, o.id);
+      })
+      .filter(hasData)
+      .map(o => ({
+        sfProjectDoc: o,
+        paratextProject: {
+          ...translateSourceToSelectableProjectWithLanguageTag(o.data),
+          projectId: o.id,
+          isConnectable: false,
+          isConnected: true,
+          hasUserRoleChanged: false,
+          hasUpdate: false,
+          role: SFProjectRole.ParatextObserver
+        },
+        selectableProjectWithLanguageCode: translateSourceToSelectableProjectWithLanguageTag(o.data),
+        translateSource: {
+          paratextId: o.data.paratextId,
+          projectRef: o.id,
+          name: o.data.name,
+          shortName: o.data.shortName,
+          writingSystem: o.data.writingSystem,
+          isRightToLeft: o.data.isRightToLeft
+        },
+        projectType: o.data.resourceConfig == null ? 'project' : 'resource'
+      }));
+    const usersProjectsAndResourcesOnSF: WithData<SFProjectDoc>[] = projects.map(o => o.sfProjectDoc).filter(hasData);
+
+    // Set of projects, not already on SF, that the user should have access to.
+    projects.push(
+      ...Array.from({ length: userNonSFProjectsCount }, (_, i) => ({
+        paratextId: `pt-id-${userSFProjectsAndResourcesCount + i}`,
+        name: `Test project ${userSFProjectsAndResourcesCount + i}`,
+        shortName: `P${userSFProjectsAndResourcesCount + i}`,
+        languageTag: 'en',
+        projectId: undefined,
+        isConnectable: true,
+        isConnected: false,
+        hasUserRoleChanged: false,
+        hasUpdate: false,
+        role: SFProjectRole.ParatextObserver
+      })).map((o: ParatextProject) => ({
+        paratextProject: o,
+        selectableProjectWithLanguageCode: o,
+        projectType: 'project' as const,
+        sfProjectDoc: undefined,
+        translateSource: undefined
+      }))
+    );
+
+    // Set of resources, not already on SF, that the user should have access to.
+    projects.push(
+      ...Array.from({ length: userNonSFResourcesCount }, (_, i) => ({
+        paratextId: `pt-id-${userSFProjectsAndResourcesCount + userNonSFProjectsCount + i}`,
+        name: `Test project ${userSFProjectsAndResourcesCount + userNonSFProjectsCount + i}`,
+        shortName: `P${userSFProjectsAndResourcesCount + userNonSFProjectsCount + i}`,
+        languageTag: 'en',
+        projectId: undefined,
+        isConnectable: true,
+        isConnected: false,
+        hasUserRoleChanged: false,
+        hasUpdate: false,
+        role: SFProjectRole.ParatextObserver
+      })).map((o: ParatextProject) => ({
+        paratextProject: o,
+        selectableProjectWithLanguageCode: o,
+        projectType: 'resource' as const,
+        sfProjectDoc: undefined,
+        translateSource: undefined
+      }))
+    );
+
+    const usersSFResources: TranslateSource[] = projects
+      .filter(o => o.projectType === 'resource')
+      .map(o => o.translateSource)
+      .filter(notNull);
+    const usersSFProjects: TranslateSource[] = projects
+      .filter(o => o.projectType === 'project')
+      .map(o => o.translateSource)
+      .filter(notNull);
+
+    this.activatedProjectDoc = usersProjectsAndResourcesOnSF[0];
+
+    // Now that various projects and resources are defined with known SF project ids, and as various needed types, write
+    // the sf project 0's translate config values.
+    const sfProject0: SFProject = this.activatedProjectDoc.data;
+    sfProject0.translateConfig.source = usersSFResources[0];
+    sfProject0.translateConfig.draftConfig.draftingSources = [usersSFProjects[1]];
+    sfProject0.translateConfig.draftConfig.trainingSources = [usersSFResources[2], usersSFProjects[2]];
+    sfProject0.translateConfig.translationSuggestionsEnabled = false;
+    sfProject0.translateConfig.preTranslate = true;
+
+    // Use a promise that resolves after the component is created to simulate the loading of projects
+    // and resources which disables the form
+    const projectPromise = new Promise<ParatextProject[] | undefined>(resolve => {
+      this.projectsLoaded$.subscribe(() =>
+        resolve(projects.filter(o => o.projectType === 'project').map(o => o.paratextProject))
+      );
+    });
+    when(mockedParatextService.getProjects()).thenReturn(projectPromise);
+    when(mockedParatextService.getResources()).thenResolve(
+      projects.filter(o => o.projectType === 'resource').map(o => o.selectableProjectWithLanguageCode)
+    );
+    if (args.projectLoadSuccessful === false) {
+      when(mockedParatextService.getProjects()).thenReject(new Error('504 Gateway Timeout'));
+    }
+    when(mockedSFUserProjectsService.projectDocs$).thenReturn(of(usersProjectsAndResourcesOnSF));
+    when(mockedI18nService.getLanguageDisplayName(anything())).thenReturn('Test Language');
+    when(mockedI18nService.enumerateList(anything())).thenCall(items => items.join(', '));
+    when(mockedI18nService.locale).thenReturn({ helps: '' } as any);
+    when(mockedActivatedProjectService.changes$).thenReturn(of(this.activatedProjectDoc));
+    when(mockedActivatedProjectService.projectDoc).thenReturn(this.activatedProjectDoc);
+    when(mockedActivatedProjectService.projectId).thenReturn(this.activatedProjectDoc.id);
+    when(mockedActivatedProjectService.projectDoc).thenReturn(this.activatedProjectDoc);
+    this.testOnlineStatusService.setIsOnline(!!args.isOnline);
+
+    when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
+      instance(mockTrainingDataQuery)
+    );
+    when(mockTrainingDataQuery.docs).thenReturn([]);
+
+    this.fixture = TestBed.createComponent(NewConfigureSourcesComponent);
+    this.component = this.fixture.componentInstance;
+    this.fixture.detectChanges();
+    tick();
+
+    if (args.projectLoadSuccessful !== false) {
+      this.loadingFinished();
+    }
+    tick();
+    this.fixture.detectChanges();
+  }
+
+  clickLanguageCodesConfirmationCheckbox(): void {
+    const languageCodesConfirmationComponent: DebugElement = this.fixture.debugElement.query(
+      By.css('app-language-codes-confirmation')
+    );
+    const checkbox: DebugElement = languageCodesConfirmationComponent.query(By.css('input[type="checkbox"]'));
+    checkbox.nativeElement.click();
+    tick();
+    this.fixture.detectChanges();
+  }
+
+  private loadingFinished(): void {
+    this.projectsLoaded$.next();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-configure-sources/new-configure-sources.component.ts
@@ -1,0 +1,498 @@
+import { KeyValuePipe } from '@angular/common';
+import { Component, DestroyRef, EventEmitter, OnInit } from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import { MatCard, MatCardActions, MatCardContent, MatCardHeader, MatCardTitle } from '@angular/material/card';
+import { MatExpansionPanel, MatExpansionPanelHeader } from '@angular/material/expansion';
+import { MatError } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { Router } from '@angular/router';
+import { TranslocoModule } from '@ngneat/transloco';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { filter, merge, Subscription } from 'rxjs';
+import { NoticeComponent } from 'src/app/shared/notice/notice.component';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { isNetworkError } from 'xforge-common/command.service';
+import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { DialogService } from 'xforge-common/dialog.service';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { ExternalUrlService } from 'xforge-common/external-url.service';
+import { FileService } from 'xforge-common/file.service';
+import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
+import { ElementState } from 'xforge-common/models/element-state';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { SFUserProjectsService } from 'xforge-common/user-projects.service';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { environment } from '../../../../environments/environment';
+import { hasData, notNull } from '../../../../type-utils';
+import { SelectableProject, SelectableProjectWithLanguageCode } from '../../../core/models/selectable-project';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
+import { ParatextService } from '../../../core/paratext.service';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { ProjectSelectComponent } from '../../../project-select/project-select.component';
+import { ConfirmOnLeave } from '../../../shared/project-router.guard';
+import { projectLabel } from '../../../shared/utils';
+import { isSFProjectSyncing } from '../../../sync/sync.component';
+import {
+  DraftSourcesAsSelectableProjectArrays,
+  projectToDraftSources,
+  translateSourceToSelectableProjectWithLanguageTag
+} from '../draft-utils';
+import { LanguageCodesConfirmationComponent } from '../language-codes-confirmation/language-codes-confirmation.component';
+import { SupportedBackTranslationLanguagesDialogComponent } from '../supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component';
+import { TrainingDataMultiSelectComponent } from '../training-data/training-data-multi-select.component';
+import { TrainingDataService } from '../training-data/training-data.service';
+
+/** Status for a project, which may or may not be at SF. */
+export interface ProjectStatus {
+  shortName: string;
+  knownToBeOnSF: boolean;
+  isSyncing?: boolean;
+  lastSyncSuccessful?: boolean;
+}
+
+/** Enables user to configure settings for drafting. */
+@Component({
+  selector: 'app-new-configure-sources',
+  imports: [
+    KeyValuePipe,
+    MatButton,
+    MatIcon,
+    MatCard,
+    MatExpansionPanel,
+    MatExpansionPanelHeader,
+    MatCardActions,
+    MatCardHeader,
+    MatCardContent,
+    MatCardTitle,
+    MatError,
+    TranslocoModule,
+    MatProgressSpinner,
+    LanguageCodesConfirmationComponent,
+    TrainingDataMultiSelectComponent,
+    ProjectSelectComponent,
+    NoticeComponent
+  ],
+  templateUrl: './new-configure-sources.component.html',
+  styleUrl: './new-configure-sources.component.scss'
+})
+export class NewConfigureSourcesComponent extends DataLoadingComponent implements OnInit, ConfirmOnLeave {
+  // Expose ElementState enum to template.
+  ElementState = ElementState;
+
+  trainingSources: (SelectableProjectWithLanguageCode | undefined)[] = [];
+  trainingTargets: SFProjectProfile[] = [];
+  draftingSources: (SelectableProjectWithLanguageCode | undefined)[] = [];
+  availableTrainingFiles: Readonly<TrainingData>[] = [];
+
+  projects?: SelectableProject[];
+  resources?: SelectableProject[];
+  // Projects that can be an already selected value, but not necessarily given as an option in the menu
+  nonSelectableProjects: SelectableProject[] = [];
+
+  languageCodeConfirmationMessageIfUserTriesToContinue: I18nKeyForComponent<'draft_sources'> | null = null;
+  clearLanguageCodeConfirmationCheckbox = new EventEmitter<void>();
+
+  /** Whether some projects are syncing currently. */
+  syncStatus: Map<string, ProjectStatus> = new Map<string, ProjectStatus>();
+
+  /** SF projects and resources that the current user is on at SF. */
+  userConnectedProjectsAndResources: SFProjectProfileDoc[] = [];
+
+  protected changesMade = false;
+
+  private controlStates = new Map<string, ElementState>();
+  private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
+  private trainingDataQuerySubscription?: Subscription;
+  private savedTrainingFiles?: Readonly<TrainingData>[];
+
+  constructor(
+    private readonly activatedProjectService: ActivatedProjectService,
+    private readonly destroyRef: DestroyRef,
+    private readonly paratextService: ParatextService,
+    private readonly dialogService: DialogService,
+    private readonly projectService: SFProjectService,
+    private readonly userProjectsService: SFUserProjectsService,
+    private readonly trainingDataService: TrainingDataService,
+    private readonly router: Router,
+    private readonly onlineStatus: OnlineStatusService,
+    readonly urls: ExternalUrlService,
+    readonly i18n: I18nService,
+    noticeService: NoticeService,
+    private readonly errorReportingService: ErrorReportingService,
+    private readonly fileService: FileService
+  ) {
+    super(noticeService);
+  }
+
+  ngOnInit(): void {
+    this.activatedProjectService.changes$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectDoc => {
+      if (projectDoc?.data != null) {
+        const { trainingSources, trainingTargets, draftingSources } = projectToDraftSources(projectDoc.data);
+        if (trainingSources.length > 2) throw new Error('More than 2 training sources is not supported');
+        if (draftingSources.length > 1) throw new Error('More than 1 drafting source is not supported');
+        if (trainingTargets.length !== 1) throw new Error('Exactly 1 training target is required');
+
+        this.trainingSources = trainingSources.map(translateSourceToSelectableProjectWithLanguageTag);
+
+        this.trainingTargets = trainingTargets;
+        this.draftingSources = draftingSources.map(translateSourceToSelectableProjectWithLanguageTag);
+        this.nonSelectableProjects = [...this.trainingSources.filter(notNull), ...this.draftingSources.filter(notNull)];
+
+        if (this.draftingSources.length < 1) this.draftingSources.push(undefined);
+        if (this.trainingSources.length < 1) this.trainingSources.push(undefined);
+
+        await this.initializeTrainingFiles(projectDoc);
+      }
+    });
+
+    this.userProjectsService.projectDocs$
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
+      .subscribe((projects?: SFProjectProfileDoc[]) => {
+        if (projects == null) return;
+        this.userConnectedProjectsAndResources = projects.filter(project => project.data != null);
+      });
+
+    this.onlineStatus.onlineStatus$
+      .pipe(
+        quietTakeUntilDestroyed(this.destroyRef),
+        filter(isOnline => isOnline)
+      )
+      .subscribe(() => this.loadProjects());
+  }
+
+  private async initializeTrainingFiles(projectDoc: SFProjectProfileDoc): Promise<void> {
+    // Query for all training data files in the project
+    this.trainingDataQuery?.dispose();
+    this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id, this.destroyRef);
+    this.trainingDataQuerySubscription?.unsubscribe();
+
+    // Subscribe to the training data query results changes
+    this.trainingDataQuerySubscription = merge(
+      this.trainingDataQuery.localChanges$,
+      this.trainingDataQuery.ready$,
+      this.trainingDataQuery.remoteChanges$,
+      this.trainingDataQuery.remoteDocChanges$
+    )
+      .pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false }))
+      .subscribe(() => {
+        const removedFiles =
+          this.savedTrainingFiles?.filter(saved => !this.availableTrainingFiles.includes(saved)) ?? [];
+        const addedFiles = this.availableTrainingFiles.filter(selected => !this.savedTrainingFiles?.includes(selected));
+
+        this.savedTrainingFiles =
+          this.trainingDataQuery?.docs.filter(d => d.data != null && d.data.deleted !== true).map(d => d.data!) ?? [];
+        this.availableTrainingFiles = this.savedTrainingFiles
+          .filter(d => removedFiles.findIndex(f => f.dataId === d.dataId) === -1)
+          .concat(addedFiles);
+      });
+  }
+
+  get issueEmail(): string {
+    return environment.issueEmail;
+  }
+
+  get appOnline(): boolean {
+    return this.onlineStatus.isOnline;
+  }
+
+  get loading(): boolean {
+    return !this.isLoaded;
+  }
+
+  get referenceLanguageDisplayName(): string {
+    const uniqueTags = Array.from(new Set(this.trainingSources.filter(notNull).map(p => p.languageTag)));
+    const displayNames = uniqueTags.map(tag => this.i18n.getLanguageDisplayName(tag) ?? tag);
+    return this.i18n.enumerateList(displayNames);
+  }
+
+  get sourceLanguageDisplayName(): string | undefined {
+    const definedSources = this.draftingSources.filter(notNull);
+
+    if (definedSources.length > 1) throw new Error('Multiple drafting sources not supported');
+    else if (definedSources.length < 1) return undefined;
+    else return this.i18n.getLanguageDisplayName(definedSources[0].languageTag);
+  }
+
+  get targetLanguageDisplayName(): string | undefined {
+    if (this.trainingTargets.length !== 1) throw new Error('Multiple training targets not supported');
+
+    return this.i18n.getLanguageDisplayName(this.trainingTargets[0]!.writingSystem.tag);
+  }
+
+  get currentProjectShortName(): string {
+    return this.activatedProjectService.projectDoc?.data?.shortName ?? '';
+  }
+
+  parentheses(value?: string): string {
+    return value ? `(${value})` : '';
+  }
+
+  onTrainingDataSelect(newTrainingFiles: TrainingData[]): void {
+    this.availableTrainingFiles = newTrainingFiles;
+    this.changesMade = true;
+  }
+
+  async loadProjects(): Promise<void> {
+    this.loadingStarted();
+    try {
+      [this.projects, this.resources] = await Promise.all([
+        this.paratextService.getProjects(),
+        this.paratextService.getResources()
+      ]);
+    } catch (error) {
+      if (!isNetworkError(error)) {
+        this.errorReportingService.silentError(
+          'Error occurred getting projects and resources',
+          ErrorReportingService.normalizeError(error)
+        );
+      }
+    } finally {
+      this.loadingFinished();
+    }
+  }
+
+  get draftSourcesAsArray(): DraftSourcesAsSelectableProjectArrays {
+    return {
+      draftingSources: this.draftingSources.filter(notNull),
+      trainingSources: this.trainingSources.filter(notNull),
+      trainingTargets: this.trainingTargets
+        .filter(notNull)
+        .map(t => translateSourceToSelectableProjectWithLanguageTag(t))
+    };
+  }
+
+  projectPlaceholder(project: SelectableProject | undefined): string {
+    return project == null ? '' : projectLabel(project);
+  }
+
+  /** Returns all Paratext IDs that should not be selectable as a draft source.
+   * @param draftSources The array of draftSources currently selected (specific to training or drafting).
+   * @param selectedId The currently selected paratextId that should be visible in the list of sources.
+   */
+  getHiddenParatextIds(draftSources: ({ paratextId: string } | undefined)[], selectedId?: string): string[] {
+    return [...draftSources, ...this.trainingTargets]
+      .filter(p => p != null && p.paratextId !== selectedId)
+      .map(p => p!.paratextId);
+  }
+
+  sourceSelected(
+    array: (SelectableProject | SFProjectProfile | undefined)[],
+    index: number,
+    paratextId: string | undefined
+  ): void {
+    // When still loading projects, the project selectors will temporarily set the value to null
+    if (!this.isLoaded) return;
+
+    const selectedProject: SelectableProject | null =
+      this.projects?.find(p => p.paratextId === paratextId) ??
+      this.resources?.find(r => r.paratextId === paratextId) ??
+      this.nonSelectableProjects.find(p => p.paratextId === paratextId) ??
+      null;
+
+    // The project select component will "select" the project we programmatically set, so prevent mistakenly indicating
+    // that the user made a change
+    if (selectedProject?.paratextId === array[index]?.paratextId) return;
+
+    this.changesMade = true;
+
+    if (selectedProject != null) {
+      array[index] = selectedProject;
+      this.clearLanguageCodeConfirmationCheckbox.emit();
+    } else {
+      array[index] = undefined;
+    }
+  }
+
+  get allowAddingATrainingSource(): boolean {
+    return this.trainingSources.length < 2 && this.trainingSources.every(notNull);
+  }
+
+  get allProjectsSavedAndSynced(): boolean {
+    return (
+      this.getControlState('projectSettings') === ElementState.Submitted &&
+      Array.from(this.syncStatus.values()).every(entry => entry.isSyncing === false)
+    );
+  }
+
+  cancel(): void {
+    this.navigateToDrafting();
+  }
+
+  async confirmLeave(): Promise<boolean> {
+    if (this.changesMade && this.getControlState('projectSettings') == null) {
+      const confirmed = await this.dialogService.confirm(
+        this.i18n.translate('draft_sources.discard_changes_confirmation'),
+        this.i18n.translate('draft_sources.leave_and_discard'),
+        this.i18n.translate('draft_sources.stay_on_page')
+      );
+      if (confirmed) {
+        const addedFiles = this.availableTrainingFiles.filter(selected => !this.savedTrainingFiles?.includes(selected));
+        addedFiles.forEach(f =>
+          this.fileService.deleteFile(
+            FileType.TrainingData,
+            this.activatedProjectService.projectId!,
+            TrainingDataDoc.COLLECTION,
+            f.dataId,
+            f.ownerRef
+          )
+        );
+      }
+
+      return confirmed;
+    }
+
+    return Promise.resolve(true);
+  }
+
+  navigateToDrafting(): void {
+    void this.router.navigate(['/projects', this.activatedProjectService.projectId, 'draft-generation']);
+  }
+
+  async save(): Promise<void> {
+    const currentProjectDoc: SFProjectProfileDoc | undefined = this.activatedProjectService.projectDoc;
+    if (!hasData(currentProjectDoc)) throw new Error('Project doc or data is null');
+
+    const definedSources: SelectableProjectWithLanguageCode[] = this.draftingSources.filter(notNull);
+    const definedReferences: SelectableProjectWithLanguageCode[] = this.trainingSources.filter(notNull);
+
+    let messageKey: I18nKeyForComponent<'draft_sources'> | undefined;
+    if (definedSources.length === 0 && definedReferences.length === 0) {
+      messageKey = 'select_at_least_one_source_and_reference';
+    } else if (definedSources.length === 0) messageKey = 'select_at_least_one_source';
+    else if (definedReferences.length === 0) messageKey = 'select_at_least_one_reference';
+    else if (this.languageCodeConfirmationMessageIfUserTriesToContinue) {
+      messageKey = this.languageCodeConfirmationMessageIfUserTriesToContinue;
+    }
+    if (messageKey) {
+      void this.dialogService.message(this.i18n.translate(`draft_sources.${messageKey}`));
+      return;
+    }
+
+    const removedFiles = this.savedTrainingFiles?.filter(saved => !this.availableTrainingFiles.includes(saved)) ?? [];
+    const addedFiles = this.availableTrainingFiles.filter(selected => !this.savedTrainingFiles?.includes(selected));
+
+    removedFiles.forEach(f => this.trainingDataService.deleteTrainingDataAsync(f));
+    addedFiles.forEach(f => this.trainingDataService.createTrainingDataAsync(f));
+
+    const sourcesSettingsChange: DraftSourcesSettingsChange = sourceArraysToSettingsChange(
+      definedReferences,
+      definedSources,
+      this.trainingTargets,
+      this.availableTrainingFiles.map(td => td.dataId),
+      currentProjectDoc.data.paratextId
+    );
+    await this.checkUpdateStatus(
+      'projectSettings',
+      this.projectService.onlineUpdateSettings(currentProjectDoc.id, sourcesSettingsChange)
+    );
+    this.monitorSyncStatus();
+  }
+
+  private async checkUpdateStatus(setting: string, updatePromise: Promise<void>): Promise<void> {
+    this.controlStates.set(setting, ElementState.Submitting);
+    try {
+      await updatePromise;
+      this.controlStates.set(setting, ElementState.Submitted);
+    } catch (error) {
+      this.controlStates.set(setting, ElementState.Error);
+      if (isNetworkError(error)) return;
+      console.error('Error updating project settings', error);
+      throw error;
+    }
+  }
+
+  private monitorSyncStatus(): void {
+    this.syncStatus.clear();
+    const chosenProjects: SelectableProject[] = [
+      ...this.trainingSources.filter(source => source != null),
+      ...this.trainingTargets.filter(target => target != null),
+      ...this.draftingSources.filter(source => source != null)
+    ];
+
+    for (const givenProject of chosenProjects) {
+      const projectDoc: SFProjectProfileDoc | undefined = this.userConnectedProjectsAndResources.find(
+        p => p.data?.paratextId === givenProject.paratextId
+      );
+      if (projectDoc == null || projectDoc.data == null) {
+        // If the user isn't on the project yet, it may still be being created. Tho when we don't show the sync status
+        // until the project setting is saved, this might not ever be used.
+
+        const status: ProjectStatus = { shortName: givenProject.shortName, knownToBeOnSF: false };
+        this.syncStatus.set(givenProject.paratextId, status);
+      } else {
+        const projectStatus: ProjectStatus | undefined = this.syncStatus.get(projectDoc.data.paratextId);
+        if (projectStatus == null || projectStatus.knownToBeOnSF === false) {
+          const updateSyncStatusForProject = (projectDoc: SFProjectProfileDoc): void => {
+            if (projectDoc.data == null) throw new Error('Project doc data is null');
+            const status: ProjectStatus = {
+              shortName: projectDoc.data.shortName,
+              knownToBeOnSF: true,
+              isSyncing: isSFProjectSyncing(projectDoc.data),
+              lastSyncSuccessful: projectDoc.data.sync.lastSyncSuccessful === true
+            };
+            this.syncStatus.set(projectDoc.data.paratextId, status);
+          };
+
+          updateSyncStatusForProject(projectDoc);
+          projectDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
+            updateSyncStatusForProject(projectDoc);
+          });
+        }
+      }
+    }
+  }
+
+  getControlState(setting: string): ElementState | undefined {
+    return this.controlStates.get(setting);
+  }
+
+  showModelLanguages(event: Event): void {
+    event.preventDefault();
+    this.dialogService.openMatDialog(SupportedBackTranslationLanguagesDialogComponent);
+  }
+}
+
+export interface DraftSourcesSettingsChange {
+  additionalTrainingDataFiles: string[];
+  draftingSourcesParatextIds: string[];
+  trainingSourcesParatextIds: string[];
+}
+
+/** Convert some arrays of drafting sources to a settings object that can be applied to a SF project. */
+export function sourceArraysToSettingsChange(
+  trainingSources: SelectableProject[],
+  /** It may not make sense for drafting to have no drafting source. But for specifying project settings, allow an
+   * empty setting for drafting source. */
+  draftingSources: SelectableProject[],
+  trainingTargets: SelectableProject[],
+  selectedTrainingFileIds: string[],
+  currentProjectParatextId: string
+): DraftSourcesSettingsChange {
+  // Extra precaution on array lengths for now in case the type system is being bypassed.
+  if (draftingSources.length > 1) {
+    throw new Error('Drafting sources array must contain 0 or 1 source');
+  }
+  if (trainingSources.length > 2) {
+    throw new Error('Training sources array must contain 0, 1, or 2 sources');
+  }
+  if (trainingTargets.length !== 1 || trainingTargets[0] == null) {
+    throw new Error('Training targets array must contain exactly 1 project');
+  }
+
+  const trainingTargetParatextId = trainingTargets[0].paratextId;
+  if (currentProjectParatextId !== trainingTargetParatextId) {
+    throw new Error('Training target must be the current project');
+  }
+
+  return {
+    additionalTrainingDataFiles: selectedTrainingFileIds,
+    trainingSourcesParatextIds: trainingSources.map(s => s.paratextId),
+    draftingSourcesParatextIds: draftingSources.map(s => s.paratextId)
+  };
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
 import { MatDialogClose, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { TranslocoModule } from '@ngneat/transloco';
@@ -7,7 +8,7 @@ import { NLLB_LANGUAGES, NllbLanguage, NllbLanguageDict } from '../../nllb-langu
 
 @Component({
   selector: 'app-supported-back-translation-languages-dialog',
-  imports: [MatIcon, MatDialogTitle, MatDialogContent, MatDialogClose, TranslocoModule],
+  imports: [MatIcon, MatIconButton, MatDialogTitle, MatDialogContent, MatDialogClose, TranslocoModule],
   templateUrl: './supported-back-translation-languages-dialog.component.html',
   styleUrls: ['./supported-back-translation-languages-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
@@ -1,18 +1,20 @@
 <ng-container *transloco="let t; read: 'training_data_multi_select'">
-  <mat-list class="training-data-multi-select" hideSingleSelectionIndicator>
-    @for (trainingData of availableTrainingData; track trainingData.dataId) {
-      <mat-list-item>
-        <!-- Tooltip shows full name of file since longer titles will be truncated. This can probably be removed if/when
+  @if (availableTrainingData.length > 0) {
+    <mat-list class="training-data-multi-select" hideSingleSelectionIndicator>
+      @for (trainingData of availableTrainingData; track trainingData.dataId) {
+        <mat-list-item>
+          <!-- Tooltip shows full name of file since longer titles will be truncated. This can probably be removed if/when
              we add the ability to click a file and open a dialog to see the data, along with the full title -->
-        <span [matTooltip]="trainingData.title">{{ trainingData.title }}</span>
-        @if (canDeleteTrainingData(trainingData)) {
-          <button matListItemMeta mat-icon-button (click)="deleteTrainingData(trainingData)">
-            <mat-icon [matTooltip]="t('delete')">cancel</mat-icon>
-          </button>
-        }
-      </mat-list-item>
-    }
-  </mat-list>
+          <span [matTooltip]="trainingData.title">{{ trainingData.title }}</span>
+          @if (canDeleteTrainingData(trainingData)) {
+            <button matListItemMeta mat-icon-button (click)="deleteTrainingData(trainingData)">
+              <mat-icon [matTooltip]="t('delete')">cancel</mat-icon>
+            </button>
+          }
+        </mat-list-item>
+      }
+    </mat-list>
+  }
   <button mat-flat-button (click)="openUploadDialog()" color="primary">
     <mat-icon>file_upload</mat-icon>
     {{ t("upload_spreadsheet") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -39,7 +39,8 @@
     "appearance": "Appearance",
     "appearance_device": "Device",
     "appearance_dark": "Dark",
-    "appearance_light": "Light"
+    "appearance_light": "Light",
+    "experimental_features": "Experimental features"
   },
   "attach_audio": {
     "tooltip_record": "Record audio",
@@ -342,6 +343,10 @@
     "network_request_failed": "A network request failed. Some functionality may be unavailable.",
     "out_of_space": "An error occurred because your device is out of storage space.",
     "unknown_error": "Unknown error"
+  },
+  "experimental_features_dialog": {
+    "title": "Experimental features",
+    "description": "These experimental features can be turned on or off and only apply to your account. Currently, logging out and back in will reset them. If you try them out, please leave us feedback so we can improve them."
   },
   "file_service": {
     "failed_to_save": "Failed to save your changes. Please check that you have the recommended 500 MB of free space on your device.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -413,6 +413,10 @@
     "training_language_model": "Training the language model",
     "unknown_language_code": "unknown"
   },
+  "new_configure_sources": {
+    "train_language_model": "Train the language model",
+    "generate_a_draft_from_the_language_model": "Generate a draft from the language model"
+  },
   "draft_usfm_format": {
     "cancel": "Cancel",
     "chapter_draft_does_not_exist": "The draft for this chapter does not exist",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.html
@@ -1,0 +1,24 @@
+<ng-container *transloco="let t; read: 'experimental_features_dialog'">
+  <h2 mat-dialog-title class="dialog-icon-title">
+    <span class="title-left"><mat-icon>science</mat-icon> {{ t("title") }}</span>
+    <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
+  </h2>
+  <mat-dialog-content class="mat-typography">
+    <p>{{ t("description") }}</p>
+
+    @for (feature of availableExperimentalFeatures; track feature.name; let isLast = $last) {
+      <mat-checkbox
+        class="feature-checkbox"
+        [(ngModel)]="feature.featureFlag.enabled"
+        [disabled]="feature.featureFlag.readonly"
+      >
+        <div class="feature-name">{{ feature.name }}</div>
+        @if (feature.description != null && feature.description !== "") {
+          <div class="feature-description">{{ feature.description }}</div>
+        }
+      </mat-checkbox>
+    } @empty {
+      <p>No experimental features are currently available.</p>
+    }
+  </mat-dialog-content>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.scss
@@ -1,0 +1,40 @@
+.mat-mdc-dialog-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title-left {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5em;
+}
+
+.mat-mdc-dialog-content {
+  width: 40em;
+  max-width: 100%;
+}
+
+.feature-checkbox {
+  padding-block: 0.75em;
+  width: 100%;
+  white-space: normal;
+
+  ::ng-deep .mdc-form-field {
+    align-items: flex-start;
+  }
+
+  ::ng-deep .mdc-label {
+    display: block;
+    padding-top: 10px;
+  }
+}
+
+.feature-name {
+  font-size: 1.1em;
+  font-weight: 500;
+}
+
+.feature-description {
+  margin-top: 0.25em;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.spec.ts
@@ -1,0 +1,142 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
+import { mock, when } from 'ts-mockito';
+import { ChildViewContainerComponent, configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
+import { FeatureFlag } from '../feature-flags/feature-flag.service';
+import { ExperimentalFeaturesDialogComponent } from './experimental-features-dialog.component';
+import { ExperimentalFeature, ExperimentalFeaturesService } from './experimental-features.service';
+
+const mockedExperimentalFeaturesService = mock(ExperimentalFeaturesService);
+
+describe('ExperimentalFeaturesDialogComponent', () => {
+  configureTestingModule(() => ({
+    imports: [ExperimentalFeaturesDialogComponent, getTestTranslocoModule()],
+    providers: [{ provide: ExperimentalFeaturesService, useMock: mockedExperimentalFeaturesService }]
+  }));
+
+  let overlayContainer: OverlayContainer;
+
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+  });
+
+  afterEach(() => {
+    // Prevents 'Error: Test did not clean up its overlay container content.'
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('Shows available experimental features and whether they are editable', fakeAsync(() => {
+    const env = new TestEnvironment();
+
+    expect(env.getFeatureNameText(0)).toBe('Feature A');
+    expect(env.getMatCheckbox(0).disabled).toBeFalsy();
+    expect(env.getMatCheckbox(0).checked).toBeTruthy();
+
+    expect(env.getFeatureNameText(1)).toBe('Feature B');
+    expect(env.getMatCheckbox(1).disabled).toBeTruthy();
+    expect(env.getMatCheckbox(1).checked).toBeFalsy();
+
+    expect(env.getDescriptionText(0)).toBe('Description A');
+    expect(env.getDescriptionText(1)).toBe('Description B');
+  }));
+
+  it('Updates a feature flag when its checkbox is checked or unchecked', fakeAsync(() => {
+    const env = new TestEnvironment();
+    expect(env.getFeatureEnabled(0)).toBeTruthy();
+
+    // SUT
+    env.clickMatCheckbox(0);
+    env.wait();
+
+    expect(env.getFeatureEnabled(0)).toBeFalsy();
+  }));
+});
+
+class TestEnvironment {
+  private readonly fixture: ComponentFixture<ChildViewContainerComponent>;
+  private readonly features: ExperimentalFeature[];
+
+  constructor() {
+    this.features = [
+      {
+        name: 'Feature A',
+        description: 'Description A',
+        available: () => true,
+        featureFlag: {
+          key: 'FEATURE_A',
+          description: 'Feature A',
+          position: 0,
+          readonly: false,
+          enabled: true
+        } as FeatureFlag
+      },
+      {
+        name: 'Feature B',
+        description: 'Description B',
+        available: () => true,
+        featureFlag: {
+          key: 'FEATURE_B',
+          description: 'Feature B',
+          position: 1,
+          readonly: true,
+          enabled: false
+        } as FeatureFlag
+      }
+    ];
+
+    when(mockedExperimentalFeaturesService.availableExperimentalFeatures).thenReturn(this.features);
+
+    this.fixture = TestBed.createComponent(ChildViewContainerComponent);
+    const config: MatDialogConfig = {
+      viewContainerRef: this.fixture.componentInstance.childViewContainer
+    };
+
+    // SUT
+    TestBed.inject(MatDialog).open(ExperimentalFeaturesDialogComponent, config);
+
+    this.wait();
+  }
+
+  get checkboxes(): DebugElement[] {
+    return this.fixture.debugElement.queryAll(By.directive(MatCheckbox));
+  }
+
+  get featureNames(): DebugElement[] {
+    return this.fixture.debugElement.queryAll(By.css('.feature-name'));
+  }
+
+  get descriptions(): DebugElement[] {
+    return this.fixture.debugElement.queryAll(By.css('.feature-description'));
+  }
+
+  getFeatureNameText(i: number): string {
+    return this.featureNames[i].nativeElement.textContent?.trim();
+  }
+
+  getMatCheckbox(i: number): MatCheckbox {
+    return this.checkboxes[i].injector.get(MatCheckbox);
+  }
+
+  getDescriptionText(i: number): string {
+    return this.descriptions[i].nativeElement.textContent?.trim();
+  }
+
+  getFeatureEnabled(i: number): boolean {
+    return this.features[i].featureFlag.enabled;
+  }
+
+  clickMatCheckbox(i: number): void {
+    const input: HTMLInputElement | null = this.checkboxes[i].nativeElement.querySelector('input');
+    input!.click();
+  }
+
+  wait(): void {
+    tick();
+    this.fixture.detectChanges();
+    flush();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.ts
@@ -1,0 +1,34 @@
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatIconButton } from '@angular/material/button';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatDialogClose, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
+import { MatDivider } from '@angular/material/divider';
+import { MatIcon } from '@angular/material/icon';
+import { TranslocoModule } from '@ngneat/transloco';
+import { ExperimentalFeature, ExperimentalFeaturesService } from './experimental-features.service';
+
+@Component({
+  templateUrl: './experimental-features-dialog.component.html',
+  styleUrls: ['./experimental-features-dialog.component.scss'],
+  imports: [
+    TranslocoModule,
+    MatDialogTitle,
+    MatIcon,
+    MatIconButton,
+    CdkScrollable,
+    MatDialogContent,
+    MatDialogClose,
+    MatCheckbox,
+    MatDivider,
+    FormsModule
+  ]
+})
+export class ExperimentalFeaturesDialogComponent {
+  constructor(readonly experimentalFeatures: ExperimentalFeaturesService) {}
+
+  get availableExperimentalFeatures(): ExperimentalFeature[] {
+    return this.experimentalFeatures.availableExperimentalFeatures;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { FeatureFlag, FeatureFlagService } from '../feature-flags/feature-flag.service';
+import { SFUserProjectsService } from '../user-projects.service';
+import { UserService } from '../user.service';
+
+/** Wraps a feature flag as an experimental feature, giving it a name, description, and availability check */
+export interface ExperimentalFeature {
+  name: string;
+  description: string;
+  available: () => boolean;
+  featureFlag: FeatureFlag;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ExperimentalFeaturesService {
+  constructor(
+    private readonly featureFlagService: FeatureFlagService,
+    private readonly userService: UserService,
+    private readonly userProjectsService: SFUserProjectsService
+  ) {}
+
+  public experimentalFeatures: ExperimentalFeature[] = [
+    {
+      name: 'New configure sources page',
+      description: `A new configure sources page is available for testing. It has the same functionality as the current page, but with an updated design and some additional information to help users understand the options.`,
+      available: () => this.doesUserHaveRoleOnAnyProject(SFProjectRole.ParatextAdministrator),
+      featureFlag: this.featureFlagService.newConfigureSourcesPage
+    }
+  ];
+
+  public get availableExperimentalFeatures(): ExperimentalFeature[] {
+    return this.experimentalFeatures.filter(feature => feature.available());
+  }
+
+  public get showExperimentalFeaturesInMenu(): boolean {
+    return this.availableExperimentalFeatures.length > 0;
+  }
+
+  /** Helper method for experimental features, since many of them will be limited to a particular role */
+  private doesUserHaveRoleOnAnyProject(role: SFProjectRole): boolean {
+    const projectDocs = this.userProjectsService.projectDocs ?? [];
+    return projectDocs.some(projectDoc => projectDoc.data?.userRoles[this.userService.currentUserId] === role);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url-class.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url-class.ts
@@ -27,6 +27,10 @@ export class ExternalUrls {
     return this.helps + '/understanding-drafts';
   }
 
+  get configuringSources(): string {
+    return this.helps + '/preparing-for-ai-drafting';
+  }
+
   get transceleratorImportHelpPage(): string {
     return this.helps + '/adding-questions#1850d745ac9e8003815fc894b8baaeb7';
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -370,6 +370,13 @@ export class FeatureFlagService {
     new StaticFeatureFlagStore(true)
   );
 
+  readonly newConfigureSourcesPage: ObservableFeatureFlag = new FeatureFlagFromStorage(
+    'NewConfigureSourcesPage',
+    'Show new configure sources page',
+    20,
+    this.featureFlagStore
+  );
+
   get featureFlags(): FeatureFlag[] {
     return Object.values(this).filter(value => value instanceof FeatureFlagFromStorage);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
@@ -14,7 +14,7 @@ import { UserService } from './user.service';
   providedIn: 'root'
 })
 export class SFUserProjectsService {
-  private projectDocs: Map<string, SFProjectProfileDoc> = new Map();
+  private _projectDocs: Map<string, SFProjectProfileDoc> = new Map();
   private _projectDocs$ = new BehaviorSubject<SFProjectProfileDoc[] | undefined>(undefined);
 
   constructor(
@@ -29,6 +29,10 @@ export class SFUserProjectsService {
   /** List of SF project docs the user is on. Or undefined if the information is not yet available. */
   get projectDocs$(): Observable<SFProjectProfileDoc[] | undefined> {
     return this._projectDocs$;
+  }
+
+  get projectDocs(): SFProjectProfileDoc[] | undefined {
+    return this._projectDocs$.getValue();
   }
 
   private async setup(): Promise<void> {
@@ -52,17 +56,17 @@ export class SFUserProjectsService {
     const currentProjectIds = userDoc.data!.sites[environment.siteId].projects;
 
     let removedProjectsCount = 0;
-    for (const [id, projectDoc] of this.projectDocs) {
+    for (const [id, projectDoc] of this._projectDocs) {
       if (!currentProjectIds.includes(id)) {
         removedProjectsCount++;
         void projectDoc.dispose();
-        this.projectDocs.delete(id);
+        this._projectDocs.delete(id);
       }
     }
 
     const docFetchPromises: Promise<SFProjectProfileDoc>[] = [];
     for (const id of currentProjectIds) {
-      if (!this.projectDocs.has(id)) {
+      if (!this._projectDocs.has(id)) {
         docFetchPromises.push(this.projectService.getProfile(id));
       }
     }
@@ -76,9 +80,9 @@ export class SFUserProjectsService {
     }
 
     for (const newProjectDoc of await Promise.all(docFetchPromises)) {
-      this.projectDocs.set(newProjectDoc.id, newProjectDoc);
+      this._projectDocs.set(newProjectDoc.id, newProjectDoc);
     }
-    const projects = Array.from(this.projectDocs.values()).sort((a, b) =>
+    const projects = Array.from(this._projectDocs.values()).sort((a, b) =>
       a.data == null || b.data == null ? 0 : compareProjectsForSorting(a.data, b.data)
     );
     this._projectDocs$.next(projects);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added experimental features menu option for ParatextAdministrators to manage account-scoped experimental settings via a new dialog.
  * Added a new configure sources page for draft generation, accessible behind a feature flag and integrated into the draft generation workflow.

* **Updates**
  * Extended translation support for experimental features and configure sources functionality.
  * Updated routing and navigation to support the new configure sources page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->