### PR TITLE
serval-admin: serval-builds: show requester email in build details

### DIFF
--- a/src/RealtimeServer/common/services/user-service.spec.ts
+++ b/src/RealtimeServer/common/services/user-service.spec.ts
@@ -19,6 +19,14 @@ describe('UserService', () => {
     await expect(fetchDoc(conn, USERS_COLLECTION, 'user02')).resolves.not.toThrow();
   });
 
+  it('allows serval admin to view others', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'user02', SystemRole.ServalAdmin);
+    await expect(fetchDoc(conn, USERS_COLLECTION, 'user01')).resolves.not.toThrow();
+  });
+
   it('allows system admin to edit others', async () => {
     const env = new TestEnvironment();
     await env.createData();

--- a/src/RealtimeServer/common/services/user-service.ts
+++ b/src/RealtimeServer/common/services/user-service.ts
@@ -106,7 +106,11 @@ export class UserService extends JsonDocService<User> {
   }
 
   protected allowRead(docId: string, doc: User, session: ConnectSession): boolean {
-    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin)) {
+    if (
+      session.isServer ||
+      session.roles.includes(SystemRole.SystemAdmin) ||
+      session.roles.includes(SystemRole.ServalAdmin)
+    ) {
       return true;
     }
     if (docId === session.userId) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -274,6 +274,21 @@
                         @let requesterName = requesterDisplayName(row.report.requesterSFUserId) | async;
                         <span class="detail-value">{{ requesterName ?? "Unknown" }}</span>
                       </div>
+
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Email address</span>
+                        @let requesterEmail = requesterEmailAddress(row.report.requesterSFUserId) | async;
+                        <span class="detail-value detail-value-with-copy code">
+                          @if (requesterEmail != null) {
+                            <a [href]="'mailto:' + requesterEmail">
+                              {{ requesterEmail }}
+                            </a>
+                            <app-copy [value]="requesterEmail"></app-copy>
+                          } @else {
+                            <span>-</span>
+                          }
+                        </span>
+                      </div>
                     </span>
                   </mat-card-content>
                 </mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -1,3 +1,7 @@
+a {
+  text-decoration: none;
+}
+
 .preview-notice {
   margin-top: 1rem;
   margin-bottom: 1rem;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,11 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { BehaviorSubject } from 'rxjs';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { anything, mock, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { MockConsole } from 'xforge-common/mock-console';
-import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
@@ -1173,6 +1173,24 @@ describe('ServalBuildsComponent', () => {
       expect(formatted).toBe('es (Spanish)');
     });
   });
+
+  describe('requesting user details', () => {
+    it('loads requester display name from user data', async () => {
+      const env = new TestEnvironment();
+
+      const displayName: string = await firstValueFrom(env.component['requesterDisplayName']('user02'));
+
+      expect(displayName).toBe('Test User');
+    });
+
+    it('loads requester email address from user data', async () => {
+      const env = new TestEnvironment();
+
+      const emailAddress: string | undefined = await firstValueFrom(env.component['requesterEmailAddress']('user02'));
+
+      expect(emailAddress).toBe('user02@example.com');
+    });
+  });
 });
 
 /** Provides helpers for constructing test data for ServalBuildsComponent tests. */
@@ -1184,21 +1202,22 @@ class TestEnvironment {
   >(undefined);
 
   constructor() {
-    const mockedUserProfileDoc = mock(UserProfileDoc);
-    const userProfileDoc: UserProfileDoc = instance(mockedUserProfileDoc);
-    const profileData: { displayName: string; avatarUrl: string } = {
+    const userData = {
       displayName: 'Test User',
-      avatarUrl: ''
+      avatarUrl: '',
+      email: 'user02@example.com'
     };
+    const userDoc = {
+      data: userData
+    } as UserDoc;
 
-    when(mockedUserProfileDoc.data).thenReturn(profileData);
     when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);
     when(mockNoticeService.loadingFinished(anything())).thenReturn(undefined);
     when(mockDraftGenerationService.getBuildsSince(anything())).thenReturn(this.builds$);
     when(mockDialogService.openMatDialog(anything(), anything(), anything())).thenReturn(undefined as never);
     when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
-    when(mockUserService.getProfile(anything())).thenReturn(Promise.resolve(userProfileDoc));
+    when(mockUserService.get(anything())).thenResolve(userDoc);
     when(mockI18nService.localeCode).thenReturn('en');
     when(mockI18nService.getLanguageDisplayName(anything())).thenReturn(undefined);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -28,6 +28,7 @@ import {
   firstValueFrom,
   from,
   map,
+  merge,
   Observable,
   of,
   shareReplay,
@@ -38,7 +39,7 @@ import { CopyComponent } from 'xforge-common/copy/copy.component';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
@@ -169,7 +170,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   /** Data rows, including those that are filtered out by the includeDeleted toggle. */
   private allRows: ServalBuildRow[] = [];
   private readonly dateRange$ = new BehaviorSubject<NormalizedDateRange | undefined>(undefined);
-  private readonly requesterDisplayNameCache: Map<string, Observable<string>> = new Map();
+  private readonly requesterIdentityCache: Map<string, Observable<{ displayName: string; emailAddress?: string }>> =
+    new Map();
 
   constructor(
     noticeService: NoticeService,
@@ -380,28 +382,49 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   protected requesterDisplayName(requesterSFUserId: string | undefined): Observable<string> {
-    if (requesterSFUserId == null) return of('Unknown');
+    return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.displayName));
+  }
+
+  protected requesterEmailAddress(requesterSFUserId: string | undefined): Observable<string | undefined> {
+    return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.emailAddress));
+  }
+
+  private requesterIdentity(
+    requesterSFUserId: string | undefined
+  ): Observable<{ displayName: string; emailAddress?: string }> {
+    if (requesterSFUserId == null) {
+      return of({ displayName: 'Unknown' });
+    }
 
     const requesterKey: string = requesterSFUserId;
-    const cached$: Observable<string> | undefined = this.requesterDisplayNameCache.get(requesterKey);
+    const cached$: Observable<{ displayName: string; emailAddress?: string }> | undefined =
+      this.requesterIdentityCache.get(requesterKey);
     if (cached$ != null) return cached$;
 
     // Cache the lookups so multiple rows don't need to request the same thing.
-    const displayName$: Observable<string> = from(this.userService.getProfile(requesterSFUserId)).pipe(
-      switchMap((userProfileDoc: UserProfileDoc) =>
-        userProfileDoc.changes$.pipe(
+    const identity$: Observable<{ displayName: string; emailAddress?: string }> = from(
+      this.userService.get(requesterSFUserId)
+    ).pipe(
+      // This switchMap to changes$ and remoteChanges$ lets us cache Observables with information that stays up-to-date.
+      switchMap((userDoc: UserDoc) =>
+        merge([userDoc.changes$, userDoc.remoteChanges$]).pipe(
           startWith(undefined),
           map(() => {
-            const displayName: string | undefined = userProfileDoc.data?.displayName?.trim();
-            return isPopulatedString(displayName) ? displayName : 'Unknown';
+            const displayName: string | undefined = userDoc.data?.displayName?.trim();
+            const emailAddress: string | undefined = userDoc.data?.email?.trim();
+            return {
+              displayName: isPopulatedString(displayName) ? displayName : 'Unknown',
+              emailAddress: isPopulatedString(emailAddress) ? emailAddress : undefined
+            };
           })
         )
       ),
       shareReplay(1),
-      catchError(() => of('Unknown'))
+      catchError(() => of({ displayName: 'Unknown' }))
     );
-    this.requesterDisplayNameCache.set(requesterKey, displayName$);
-    return displayName$;
+
+    this.requesterIdentityCache.set(requesterKey, identity$);
+    return identity$;
   }
 
   private async loadBuilds(range: NormalizedDateRange, isOnline: boolean): Promise<void> {


### PR DESCRIPTION
This patch modifies the Requesting user area in the expanded information of a Serval build so it shows the user's email address.